### PR TITLE
ci: reduce cron frequency from every 4h to once daily

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,8 +2,8 @@ name: "Automated Discovery & Sync"
 
 on:
   schedule:
-    # Run every 4 hours
-    - cron: '0 */4 * * *'
+    # Run once daily at 06:00 UTC
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       discover_only:


### PR DESCRIPTION
## Summary

- **Current cadence:** every 4 hours (6 runs/day), 11 parallel jobs per run (5 discover + 5 sync + 1 heal)
- **New cadence:** once daily at 06:00 UTC, same job structure
- **Estimated minutes saved:** ~4850 min/month (from ~5800 to ~950)

## Rationale

depup is an npm package mirror. Discovery checks the npm popularity list + user-submitted packages for new entries; sync re-bumps existing package dependencies to latest. Neither of these has a sub-day freshness requirement:

- npm packages don't update so frequently that a 24h lag matters for a mirror
- Users submitting package requests trigger the `process-package-request.yml` workflow immediately (issue-triggered), so that flow is unaffected
- `workflow_dispatch` remains available for on-demand full runs at any time
- The weekly `refresh-list.yml` (curated package list from npm popularity) is already at an appropriate cadence and is unchanged

Every 4h was generating the dominant share of the account's Actions usage (~5800 min/month vs a 3000 min/month free tier). Daily brings this to ~950 min/month for this workflow alone.