### PR TITLE
chore: trim cron cadence to 8h + 3 shards (cut commit noise, not minutes)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: "Automated Discovery & Sync"
 
 on:
   schedule:
-    - cron: "0 */4 * * *"
+    - cron: "0 */8 * * *"
   workflow_dispatch:
     inputs:
       discover_only:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4]
+        shard: [0, 1, 2]
 
     steps:
       - name: Checkout
@@ -64,9 +64,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: '5'
+          SHARD_TOTAL: '3'
         run: |
-          echo "Starting package discovery (shard ${{ matrix.shard }}/5)..."
+          echo "Starting package discovery (shard ${{ matrix.shard }}/3)..."
           npm run cron:discover
 
       - name: Commit and Push Changes
@@ -154,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4]
+        shard: [0, 1, 2]
 
     steps:
       - name: Checkout (latest main, including discover pushes)
@@ -190,9 +190,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: '5'
+          SHARD_TOTAL: '3'
         run: |
-          echo "Starting package sync (shard ${{ matrix.shard }}/5)..."
+          echo "Starting package sync (shard ${{ matrix.shard }}/3)..."
           npm run cron:sync
 
       - name: Commit and Push Changes


### PR DESCRIPTION
## Summary

Trims the automated discovery/sync cron in `cron.yml` to reduce **commit churn into `main`**, not CI minutes.

**Important framing:** `chiefmikey/depup` is a **public** repo, so GitHub-hosted `ubuntu-latest` Actions minutes are **free and unlimited** -- there is no billed minute budget to optimize. The genuine cost this PR reduces is automated **commit noise** (16-45 De Pup commits/day into `main`) and npm-registry politeness.

## Changes (`cron.yml` only)

| | Before | After |
|---|---|---|
| Schedule | every 4h (`0 */4 * * *`) -- 6 runs/day | every 8h (`0 */8 * * *`) -- 3 runs/day |
| discover shards | `[0,1,2,3,4]` (5) | `[0,1,2]` (3) |
| sync shards | `[0,1,2,3,4]` (5) | `[0,1,2]` (3) |
| `SHARD_TOTAL` | `'5'` | `'3'` |

Net: ~50% fewer scheduled firings and 40% fewer shard jobs per run -> roughly **half the daily automated commit volume**.

## Freshness tradeoff

Minor and bounded: worst-case a dependency bump lands ~8h later instead of ~4h. **User submissions are unaffected** -- they publish immediately via `process-package-request.yml` (issue-triggered), which this PR does not touch.

## Validation

- `python3 yaml.safe_load` parses clean; jobs `[discover, sync, heal]` intact, schedule + both shard matrices confirmed `[0,1,2]`.
- Diff is config-only (schedule, matrix, `SHARD_TOTAL`, two log strings). No logic changes.