### PR TITLE
docs: sync CLAUDE.md + handoff to merged cron cadence (8h/3 shards)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
 # DepUp -- Project CLAUDE.md
 
 ## Project Overview
-Automated npm package factory. Downloads npm packages, bumps all dependencies to latest, tests, publishes as `@depup/package-name`. 1000+ packages managed, processed every 4 hours, user submissions publish immediately.
+Automated npm package factory. Downloads npm packages, bumps all dependencies to latest, tests, publishes as `@depup/package-name`. 1000+ packages managed, processed every 8 hours, user submissions publish immediately.
 
 ## Tech Stack
 - **Runtime:** Node.js 24 LTS, ESM (`"type": "module"`)
 - **Language:** JavaScript (.mjs files)
 - **Linting:** ESLint via `mikey-pro` (strict: unicorn, security, promise, perfectionist)
 - **Testing:** Jest with `--experimental-vm-modules` (config in `jest.config.cjs`)
-- **CI:** GitHub Actions, 5 parallel shards, GPG-signed commits as "De Pup"
+- **CI:** GitHub Actions, 3 parallel shards, GPG-signed commits as "De Pup"
 
 ## Architecture
 ```
@@ -34,7 +34,7 @@ config/
   user-packages.json     # User-submitted packages (via GitHub issues)
   security-allowlist.json
 .github/workflows/
-  cron.yml               # Every 4h: discover + sync (5 shards) + heal
+  cron.yml               # Every 8h: discover + sync (3 shards) + heal
   process-package-request.yml # Issue-triggered: validate, publish, commit, close
   refresh-list.yml       # Weekly: refresh curated list from npm popularity
   bump.yml               # On push: re-sync (skips De Pup commits)
@@ -68,8 +68,8 @@ npm run heal                # Self-healing repairs
 6. Trigger: `labeled` only (not `opened` -- prevents duplicate runs)
 
 ## Cron Architecture
-- **Every 4h:** discover (curated + user lists) + sync (dep bump check) + heal
-- **5 shards** parallel, 5 concurrent packages per shard (async child processes)
+- **Every 8h:** discover (curated + user lists) + sync (dep bump check) + heal
+- **3 shards** parallel, 5 concurrent packages per shard (async child processes)
 - **Weekly:** refresh curated list from npm search API (1000 packages)
 - **Dep checking:** batches of 10, abort-on-first-match, minor/major only
 - **Revision pruning:** keeps last 5 per version, prunes integrity.json entries too

--- a/docs/handoff/2026-06-06.md
+++ b/docs/handoff/2026-06-06.md
@@ -1,0 +1,48 @@
+# Handoff -- 2026-06-06
+
+_Status: COMPLETED_
+
+## Goal
+Reduce depup GitHub Actions cron churn. (Originally framed as "minute burn" -- corrected below.)
+
+## Key finding (the important one)
+`chiefmikey/depup` is a **PUBLIC** repo, so GitHub-hosted `ubuntu-latest` Actions
+minutes are **free and unlimited**. There is no billed minute budget to optimize --
+the original task premise ("reduce cron minute burn toward a sustainable budget")
+does not apply. Confirmed via `gh repo view` (`"visibility":"PUBLIC"`) and the
+existing memory note `project_github_canonical_architecture.md`.
+
+The real, genuine cost was **commit noise**: 16-45 De Pup commits/day into `main`
+from the every-4h cron. The work was reframed and shipped honestly as churn
+reduction, NOT minute savings. No fabricated budget numbers were put in the commit
+or PR.
+
+## What landed
+- **PR #1246 -- MERGED** (2026-06-06T05:01Z, squash). `cron.yml` only:
+  - schedule `0 */4 * * *` -> `0 */8 * * *` (6 runs/day -> 3)
+  - discover + sync matrix `[0,1,2,3,4]` -> `[0,1,2]` (5 -> 3 shards)
+  - `SHARD_TOTAL '5'` -> `'3'` (both jobs); log strings updated `/5` -> `/3`
+  - Validated: `yaml.safe_load` clean, jobs `[discover, sync, heal]` intact.
+  - Net: ~50% fewer scheduled firings + 40% fewer shard jobs -> ~half the daily
+    automated commit volume. Freshness lag bounded ~8h worst-case. User submissions
+    unaffected (`process-package-request.yml`, issue-triggered, untouched).
+- **Docs synced to the merged reality** (this closeout commit):
+  - `CLAUDE.md`: 5 stale "every 4h" / "5 shards" refs -> 8h / 3 shards.
+  - Memory `project_github_canonical_architecture.md`: appended the 2026-06-05
+    cadence-trim entry (project-local memory dir; not in configs repo).
+
+## What was deliberately NOT done
+- Did **not** run a multi-agent minute-tally workflow -- the numbers are moot for a
+  free public repo; it would have burned tokens to produce a fiction.
+- Did **not** touch `depup.yml` / `depup-secure.yml` (manual-dispatch, no cron cost),
+  `performance.yml` / `refresh-list.yml` (weekly, negligible), or the issue-triggered
+  publish path (intentionally kept instant).
+
+## Open threads
+None. Fully landed and verified on `main`. Nothing trapped.
+
+## If you want to tune further
+Cadence/shards are one-line changes in `cron.yml`. 6h (`0 */6 * * *`) or 4 shards
+are trivial dials if 8h freshness proves too slow. Constraints that DO bind (not
+minutes): 6h job timeout, 20 concurrent jobs (uses ~10), 7GB RAM -> code pins
+`concurrentPackages=5`.


### PR DESCRIPTION
Follow-up to #1246 (merged). Brings docs in line with the merged `cron.yml`:

- `CLAUDE.md`: 5 stale "every 4h" / "5 shards" refs -> 8h / 3 shards.
- `docs/handoff/2026-06-06.md`: session handoff documenting the change and the **minutes-are-free** reframing (public repo -> free unlimited Actions; the trim reduces commit noise, not a billed budget).

Docs-only, no code/workflow logic touched.