### PR TITLE
chore: enforce per-file 80% coverage threshold in jest config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: "Unit Tests"
 
 # Runs the unit suite (no integration tests — those hit the live npm registry).
-# Scoped to source paths so the every-4h De Pup package-data commits do not
+# Scoped to source paths so the every-8h De Pup package-data commits do not
 # trigger redundant test runs.
 on:
   push:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,4 @@
 module.exports = {
-  testEnvironment: 'node',
-  testMatch: ['**/scripts/__tests__/**/*.test.js'],
-  testPathIgnorePatterns: ['/node_modules/', '/.*\\.test-temp/', '/.*/rev-.*/', '<rootDir>/depup/'],
   collectCoverageFrom: [
     'scripts/**/*.mjs',
     '!scripts/**/*.test.js',
@@ -10,6 +7,17 @@ module.exports = {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
+  coverageThreshold: {
+    'scripts/**/*.mjs': { branches: 80, lines: 80 },
+  },
+  testEnvironment: 'node',
+  testMatch: ['**/scripts/__tests__/**/*.test.js'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    String.raw`/.*\.test-temp/`,
+    '/.*/rev-.*/',
+    '<rootDir>/depup/',
+  ],
   transform: {},
   transformIgnorePatterns: ['node_modules/(?!(chalk|ora|inquirer|commander)/)'],
 };


### PR DESCRIPTION
## Summary

- Adds `coverageThreshold` to `jest.config.cjs` using jest's per-file glob key (`scripts/**/*.mjs`) so each of the 14 tracked source files must individually maintain >=80% lines and >=80% branches. This locks in the bar established by PR #1251 — a future regression on any single file will fail CI immediately rather than being masked by aggregate numbers.
- Fixes a stale comment in `.github/workflows/test.yml`: `every-4h` → `every-8h` (cron runs every 8h, matching `cron.yml`).
- `eslint --fix` auto-applied prettier/perfectionist cleanup to `jest.config.cjs` (key ordering, array formatting, `String.raw` for the regex pattern) — no logic changes.

## Test Plan

- [x] `npm run test:coverage` passed locally — 1288 tests, 9 suites, all 14 files above 80/80:

```
--------------------------|---------|----------|---------|---------|
File                      | % Stmts | % Branch | % Funcs | % Lines |
--------------------------|---------|----------|---------|---------|
All files                 |   93.27 |    93.12 |   94.48 |   93.24 |
 add-package.mjs          |   97.36 |      100 |     100 |   97.26 |
 cli.mjs                  |    88.8 |    97.72 |   68.42 |    88.8 |
 compatibility-test.mjs   |   96.92 |    95.91 |     100 |   96.92 |
 cron-discover.mjs        |   96.61 |    93.33 |   93.33 |   96.57 |
 cron-sync.mjs            |      96 |    92.22 |     100 |      96 |
 depup-security.mjs       |   81.37 |    82.22 |   89.28 |   81.37 |
 depup.mjs                |   96.55 |    96.29 |   96.55 |   96.53 |
 generate-readme.mjs      |   96.26 |    94.33 |     100 |   96.26 |
 heal.mjs                 |   97.52 |     96.8 |     100 |   97.52 |
 integrity-meter.mjs      |   96.52 |    98.34 |     100 |   96.52 |
 refresh-curated-list.mjs |   95.55 |     90.9 |     100 |   95.23 |
 security-approval.mjs    |   91.81 |     88.7 |    87.5 |   91.81 |
 security-scan.mjs        |   83.18 |    80.99 |    91.3 |   83.11 |
 utilities.mjs            |    93.1 |      100 |     100 |    93.1 |
--------------------------|---------|----------|---------|---------|
Test Suites: 9 passed, 9 total
Tests:       1288 passed, 1288 total
```

- [x] `npx eslint jest.config.cjs` exits 0 after auto-fix
- [x] The new threshold does NOT fail the run (all files clear the bar)
