### PR TITLE
chore: repo hygiene — .nextcloudignore + devDep-bump notes

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,0 +1,6 @@
+packages/
+.claude/
+node_modules/
+coverage/
+test-results/
+.test-temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,10 @@ npm run heal                # Self-healing repairs
 - Dependencies pinned to exact versions (no `^`)
 - All classes exported: `export { ClassName }` before entry point guard
 
+## Dev Tooling (bumping depup's own devDeps)
+- Validate bumps with `npm ci` (NOT `npm install --legacy-peer-deps`) before declaring green -- CI runs strict `npm ci` and `--legacy-peer-deps` masks peer conflicts that then fail in CI
+- `mikey-pro` 10.3.x requires explicit `eslint@^10`, `prettier`, and `stylelint@^16` peer deps declared in `package.json` (exact-pinned) -- transitive resolution lands eslint 9 and breaks `npm ci`
+
 ## Common Mistakes
 - `mikey-pro` sets `noInlineConfig: true` -- use eslint.config.js overrides, not inline comments
 - `chalk.orange` does not exist -- use `chalk.hex('#FFA500')`


### PR DESCRIPTION
## Summary
Salvages the two genuinely-unique files from the stale chore/nextcloudignore branch (the devDep bumps it also carried are already on main and newer, so discarded).

- .nextcloudignore — stops the Nextcloud desktop client from syncing the churning 118MB packages/ tree (rewritten every cron cycle), plus .claude/, node_modules/, coverage/, test artifacts. Pure local-sync hygiene; no repo/CI effect.
- CLAUDE.md — documents the mikey-pro 10.3.x peer-dep requirement + npm ci validation gotcha for future devDep bumps.

## Test Plan
No code paths touched (docs + ignore file only); test.yml correctly not triggered.