### PR TITLE
fix: engine self-healing — eliminate silent publish failures + stuck packages

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -67,7 +67,8 @@ jobs:
           SHARD_TOTAL: '3'
         run: |
           echo "Starting package discovery (shard ${{ matrix.shard }}/3)..."
-          npm run cron:discover
+          npm run cron:discover 2>&1 | tee /tmp/depup-discover.log
+          exit "${PIPESTATUS[0]}"
 
       - name: Commit and Push Changes
         run: |
@@ -144,6 +145,12 @@ jobs:
         run: |
           echo "## Discovery Shard ${{ matrix.shard }} Summary" >> $GITHUB_STEP_SUMMARY
           echo "- **Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+          summary_line=$(grep '^DEPUP_SUMMARY' /tmp/depup-discover.log 2>/dev/null || true)
+          if [ -n "$summary_line" ]; then
+            echo "- **Counts**: $summary_line" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Counts**: (no summary line found -- script may have errored)" >> $GITHUB_STEP_SUMMARY
+          fi
 
   sync:
     name: Sync (shard ${{ matrix.shard }})
@@ -193,7 +200,8 @@ jobs:
           SHARD_TOTAL: '3'
         run: |
           echo "Starting package sync (shard ${{ matrix.shard }}/3)..."
-          npm run cron:sync
+          npm run cron:sync 2>&1 | tee /tmp/depup-sync.log
+          exit "${PIPESTATUS[0]}"
 
       - name: Commit and Push Changes
         run: |
@@ -263,6 +271,12 @@ jobs:
         run: |
           echo "## Sync Shard ${{ matrix.shard }} Summary" >> $GITHUB_STEP_SUMMARY
           echo "- **Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+          summary_line=$(grep '^DEPUP_SUMMARY' /tmp/depup-sync.log 2>/dev/null || true)
+          if [ -n "$summary_line" ]; then
+            echo "- **Counts**: $summary_line" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Counts**: (no summary line found -- script may have errored)" >> $GITHUB_STEP_SUMMARY
+          fi
 
   heal:
     name: Self-Healing

--- a/.github/workflows/process-package-request.yml
+++ b/.github/workflows/process-package-request.yml
@@ -136,6 +136,20 @@ jobs:
             exit 1
           fi
 
+          # Check config/curated-packages.json (shape: { "packages": [...] })
+          if jq -e --arg p "$PACKAGE_NAME" '.packages | index($p) != null' config/curated-packages.json >/dev/null 2>&1; then
+            echo "Package $PACKAGE_NAME is already in the curated list"
+            echo "exists=true" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Check config/user-packages.json (shape: { "packages": [...] })
+          if jq -e --arg p "$PACKAGE_NAME" '.packages | index($p) != null' config/user-packages.json >/dev/null 2>&1; then
+            echo "Package $PACKAGE_NAME is already in the user-submitted list"
+            echo "exists=true" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
           echo "Package $PACKAGE_NAME is not already processed"
           echo "exists=false" >> $GITHUB_OUTPUT
 
@@ -205,9 +219,7 @@ jobs:
           PACKAGE_NAME: ${{ steps.parse.outputs.package_name }}
         run: |
           echo "Processing and publishing $PACKAGE_NAME..."
-          node scripts/depup.mjs "$PACKAGE_NAME" --bump-deps --test --publish || {
-            echo "Publish failed -- will be retried by cron"
-          }
+          node scripts/depup.mjs "$PACKAGE_NAME" --bump-deps --test --publish
 
       - name: Import GPG Key
         run: |
@@ -258,6 +270,48 @@ jobs:
             sleep $((RANDOM % 10 + attempt * 3))
             if [ "$attempt" -eq 10 ]; then
               echo "Push failed after 10 attempts"
+              exit 1
+            fi
+          done
+
+      - name: Queue for Retry on Failure
+        if: failure()
+        env:
+          PACKAGE_NAME: ${{ steps.parse.outputs.package_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          git config user.name "De Pup"
+          git config user.email "devdepup@gmail.com"
+          git config commit.gpgsign true
+          git config gpg.program gpg
+          git config user.signingkey 5A5141965C39129D
+
+          # Persist the package into user-packages.json so the next cron
+          # cycle picks it up and retries the publish.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            git fetch origin main
+            git reset --hard origin/main
+
+            # Re-add package to list (idempotent)
+            node scripts/add-package.mjs add "$PACKAGE_NAME" 2>/dev/null || true
+
+            # Stage only the config list (no package data -- publish failed)
+            git add config/user-packages.json
+            if git diff --cached --quiet; then
+              echo "Package already in list (another workflow beat us)"
+              exit 0
+            fi
+
+            git commit -m "chore: queue ${PACKAGE_NAME} for retry (publish failed in #${ISSUE_NUMBER})"
+            if git push origin main; then
+              echo "Queue push successful on attempt $attempt"
+              break
+            fi
+
+            echo "Push race on attempt $attempt, retrying..."
+            sleep $((RANDOM % 10 + attempt * 3))
+            if [ "$attempt" -eq 10 ]; then
+              echo "Queue push failed after 10 attempts"
               exit 1
             fi
           done
@@ -325,9 +379,10 @@ jobs:
               comment += 'Dependencies bumped to latest versions. Install with:\n';
               comment += '```\nnpm install @depup/' + flatName + '\n```';
             } else {
-              comment += 'Request Failed: An unexpected error occurred.\n\n';
+              comment += 'Request Received: Package queued for automatic retry.\n\n';
               comment += '**Package:** `' + packageName + '`\n\n';
-              comment += 'Please check the workflow logs for details. If this persists, please open a new issue.';
+              comment += 'Your package passed validation but could not be published in this run. DepUp has queued it and will retry automatically on the next cron cycle (within 8 hours).\n\n';
+              comment += 'This issue is left open for tracking. No action is needed on your part.';
             }
 
             comment += '\n\n---\n*This is an automated response*';

--- a/.github/workflows/process-package-request.yml
+++ b/.github/workflows/process-package-request.yml
@@ -222,6 +222,7 @@ jobs:
           node scripts/depup.mjs "$PACKAGE_NAME" --bump-deps --test --publish
 
       - name: Import GPG Key
+        if: always()
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
@@ -275,7 +276,7 @@ jobs:
           done
 
       - name: Queue for Retry on Failure
-        if: failure()
+        if: failure() && steps.npm-info.outcome == 'success' && steps.check-existing.outputs.exists == 'false'
         env:
           PACKAGE_NAME: ${{ steps.parse.outputs.package_name }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/refresh-list.yml
+++ b/.github/workflows/refresh-list.yml
@@ -5,9 +5,14 @@ on:
     - cron: "0 7 * * 0"
   workflow_dispatch: {}
 
+concurrency:
+  cancel-in-progress: false
+  group: depup-refresh-list
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 
@@ -48,4 +53,25 @@ jobs:
             exit 0
           fi
           git commit -m "chore: refresh curated package list from npm popularity data"
-          git push origin main
+          for attempt in 1 2 3; do
+            git fetch origin main
+            # Clean any unstaged changes before rebase (case-different files from packages)
+            git checkout -- . 2>/dev/null || true
+            if ! git rebase origin/main; then
+              git rebase --abort 2>/dev/null || true
+              sleep 2
+              if [ "$attempt" -eq 3 ]; then
+                echo "Rebase failed after 3 attempts"
+                exit 1
+              fi
+            elif git push origin main; then
+              echo "Push successful on attempt $attempt"
+              break
+            else
+              if [ "$attempt" -eq 3 ]; then
+                echo "Push failed after 3 attempts"
+                exit 1
+              fi
+              sleep 2
+            fi
+          done

--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -7138,6 +7138,177 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         'inner sync error',
       );
     });
+
+    it('emits DEPUP_SUMMARY line at end of successful run', async () => {
+      jestInstance.spyOn(syncer, 'getExistingPackages').mockResolvedValueOnce([]);
+
+      await syncer.main();
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringMatching(/^DEPUP_SUMMARY processed=\d+ failed=\d+ skipped=\d+$/u),
+      );
+    });
+
+    it('exits with 1 and logs SYSTEMIC FAILURE when >50% of 10+ attempts fail', async () => {
+      // Build 12 packages that will all fail
+      const packages = Array.from({ length: 12 }, (_, index) => ({
+        integrityData: {},
+        name: `fail-pkg-${index}`,
+        path: temporaryDirectory,
+        version: '1.0.0',
+      }));
+      jestInstance
+        .spyOn(syncer, 'getExistingPackages')
+        .mockResolvedValueOnce(packages);
+      jestInstance
+        .spyOn(syncer, 'syncPackage')
+        .mockRejectedValue(new Error('boom'));
+      const exitSpy = jestInstance
+        .spyOn(process, 'exit')
+        .mockImplementation(() => {});
+      syncer.rateLimitDelay = 0;
+
+      await syncer.main();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('SYSTEMIC FAILURE'),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('does NOT trigger systemic failure when fewer than 10 packages attempted', async () => {
+      const packages = Array.from({ length: 3 }, (_, index) => ({
+        integrityData: {},
+        name: `small-fail-${index}`,
+        path: temporaryDirectory,
+        version: '1.0.0',
+      }));
+      jestInstance
+        .spyOn(syncer, 'getExistingPackages')
+        .mockResolvedValueOnce(packages);
+      jestInstance
+        .spyOn(syncer, 'syncPackage')
+        .mockRejectedValue(new Error('small fail'));
+      const exitSpy = jestInstance
+        .spyOn(process, 'exit')
+        .mockImplementation(() => {});
+      syncer.rateLimitDelay = 0;
+
+      await syncer.main();
+
+      expect(exitSpy).not.toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // hasOnlyFailedRevisions (new helper for FIX 2)
+  // ─────────────────────────────────────────────────────────────────
+  describe('hasOnlyFailedRevisions', () => {
+    it('returns false when integrityData is null', () => {
+      expect(syncer.hasOnlyFailedRevisions(null, '1.0.0')).toBe(false);
+    });
+
+    it('returns false when version is not in integrityData', () => {
+      expect(syncer.hasOnlyFailedRevisions({ '2.0.0': {} }, '1.0.0')).toBe(false);
+    });
+
+    it('returns false when versionEntry is null', () => {
+      expect(syncer.hasOnlyFailedRevisions({ '1.0.0': null }, '1.0.0')).toBe(false);
+    });
+
+    it('returns false when versionEntry is an array', () => {
+      expect(syncer.hasOnlyFailedRevisions({ '1.0.0': [] }, '1.0.0')).toBe(false);
+    });
+
+    it('returns false when versionEntry has no revisions', () => {
+      expect(syncer.hasOnlyFailedRevisions({ '1.0.0': {} }, '1.0.0')).toBe(false);
+    });
+
+    it('returns false when at least one revision has status published', () => {
+      const integrityData = {
+        '1.0.0': {
+          'rev-1': { status: 'failed' },
+          'rev-2': { status: 'published' },
+        },
+      };
+      expect(syncer.hasOnlyFailedRevisions(integrityData, '1.0.0')).toBe(false);
+    });
+
+    it('returns true when all revisions have status failed', () => {
+      const integrityData = {
+        '1.0.0': {
+          'rev-1': { status: 'failed' },
+          'rev-2': { status: 'failed' },
+        },
+      };
+      expect(syncer.hasOnlyFailedRevisions(integrityData, '1.0.0')).toBe(true);
+    });
+
+    it('returns true when revisions exist but none have status published', () => {
+      const integrityData = {
+        '1.0.0': {
+          'rev-1': { status: 'pending' },
+        },
+      };
+      expect(syncer.hasOnlyFailedRevisions(integrityData, '1.0.0')).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // syncPackage -- retry when only failed revisions (FIX 2)
+  // ─────────────────────────────────────────────────────────────────
+  describe('syncPackage -- retry on all-failed revisions', () => {
+    it('retries when version matches but all revisions are failed', async () => {
+      const integrityData = {
+        '1.0.0': { 'rev-1': { status: 'failed' } },
+      };
+      const package_ = {
+        integrityData,
+        name: 'retry-pkg',
+        path: temporaryDirectory,
+        version: '1.0.0',
+      };
+      jestInstance
+        .spyOn(syncer, 'wasRecentlyProcessed')
+        .mockResolvedValueOnce(false);
+      jestInstance.spyOn(fetchModule.default, 'json').mockResolvedValueOnce({
+        'dist-tags': { latest: '1.0.0' },
+      });
+      const updateSpy = jestInstance
+        .spyOn(syncer, 'updatePackage')
+        .mockResolvedValueOnce();
+      jestInstance.spyOn(syncer, 'generateReadme').mockResolvedValueOnce();
+
+      const result = await syncer.syncPackage(package_);
+
+      expect(updateSpy).toHaveBeenCalledWith(package_, '1.0.0');
+      expect(result).toBe(true);
+    });
+
+    it('does NOT retry when version matches and at least one revision is published', async () => {
+      const integrityData = {
+        '1.0.0': { 'rev-1': { status: 'published' } },
+      };
+      const package_ = {
+        integrityData,
+        name: 'ok-pkg',
+        path: temporaryDirectory,
+        version: '1.0.0',
+      };
+      jestInstance
+        .spyOn(syncer, 'wasRecentlyProcessed')
+        .mockResolvedValueOnce(false);
+      jestInstance.spyOn(fetchModule.default, 'json').mockResolvedValueOnce({
+        'dist-tags': { latest: '1.0.0' },
+      });
+      jestInstance
+        .spyOn(syncer, 'checkDependencyUpdates')
+        .mockResolvedValueOnce(false);
+
+      const result = await syncer.syncPackage(package_);
+
+      expect(result).toBe(false);
+    });
   });
 });
 
@@ -7449,9 +7620,12 @@ describe('cron-discover.mjs -- coverage gap fill', () => {
       expect(createSpy).toHaveBeenCalledWith(pkg, temporaryDirectory);
     });
 
-    it('logs up-to-date when version already in integrity data', async () => {
+    it('logs up-to-date when version already in integrity data with a published revision', async () => {
       const integrityFile = pathModule.default.join(temporaryDirectory, 'integrity.json');
-      await fsPromises.writeFile(integrityFile, JSON.stringify({ '1.0.0': { status: 'published' } }));
+      await fsPromises.writeFile(
+        integrityFile,
+        JSON.stringify({ '1.0.0': { 'rev-1': { status: 'published' } } }),
+      );
       const pkg = { name: 'my-pkg', version: '1.0.0' };
 
       await discoverer.checkForUpdates(pkg, temporaryDirectory, integrityFile);
@@ -7461,7 +7635,10 @@ describe('cron-discover.mjs -- coverage gap fill', () => {
 
     it('calls createNewPackage with latestVersion when not in integrity data', async () => {
       const integrityFile = pathModule.default.join(temporaryDirectory, 'integrity.json');
-      await fsPromises.writeFile(integrityFile, JSON.stringify({ '1.0.0': { status: 'published' } }));
+      await fsPromises.writeFile(
+        integrityFile,
+        JSON.stringify({ '1.0.0': { 'rev-1': { status: 'published' } } }),
+      );
       const pkg = { name: 'my-pkg', version: '2.0.0' };
       const createSpy = jestInstance
         .spyOn(discoverer, 'createNewPackage')
@@ -7712,6 +7889,175 @@ describe('cron-discover.mjs -- coverage gap fill', () => {
       } else {
         delete process.env.NPM_TOKEN;
       }
+    });
+
+    it('emits DEPUP_SUMMARY line at end of successful run', async () => {
+      const originalToken = process.env.NPM_TOKEN;
+      process.env.NPM_TOKEN = 'fake-token';
+
+      jestInstance
+        .spyOn(discoverer, 'getTopPackages')
+        .mockResolvedValueOnce([{ name: 'express', version: '4.0.0' }]);
+      jestInstance.spyOn(discoverer, 'processPackage').mockResolvedValue();
+      discoverer.maxPackages = 1;
+      discoverer.rateLimitDelay = 0;
+
+      await discoverer.main();
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringMatching(/^DEPUP_SUMMARY processed=\d+ failed=\d+ skipped=\d+$/u),
+      );
+
+      if (originalToken !== undefined) {
+        process.env.NPM_TOKEN = originalToken;
+      } else {
+        delete process.env.NPM_TOKEN;
+      }
+    });
+
+    it('exits with 1 and logs SYSTEMIC FAILURE when >50% of 10+ attempts fail', async () => {
+      const originalToken = process.env.NPM_TOKEN;
+      process.env.NPM_TOKEN = 'fake-token';
+
+      const packages = Array.from({ length: 12 }, (_, index) => ({
+        name: `fail-pkg-${index}`,
+        version: '1.0.0',
+      }));
+      jestInstance
+        .spyOn(discoverer, 'getTopPackages')
+        .mockResolvedValueOnce(packages);
+      jestInstance
+        .spyOn(discoverer, 'processPackage')
+        .mockRejectedValue(new Error('publish exploded'));
+      discoverer.maxPackages = 12;
+      discoverer.rateLimitDelay = 0;
+      const exitSpy = jestInstance
+        .spyOn(process, 'exit')
+        .mockImplementation(() => {});
+
+      await discoverer.main();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('SYSTEMIC FAILURE'),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      if (originalToken !== undefined) {
+        process.env.NPM_TOKEN = originalToken;
+      } else {
+        delete process.env.NPM_TOKEN;
+      }
+    });
+
+    it('does NOT trigger systemic failure when fewer than 10 packages attempted', async () => {
+      const originalToken = process.env.NPM_TOKEN;
+      process.env.NPM_TOKEN = 'fake-token';
+
+      const packages = Array.from({ length: 3 }, (_, index) => ({
+        name: `small-fail-${index}`,
+        version: '1.0.0',
+      }));
+      jestInstance
+        .spyOn(discoverer, 'getTopPackages')
+        .mockResolvedValueOnce(packages);
+      jestInstance
+        .spyOn(discoverer, 'processPackage')
+        .mockRejectedValue(new Error('small fail'));
+      discoverer.maxPackages = 3;
+      discoverer.rateLimitDelay = 0;
+      const exitSpy = jestInstance
+        .spyOn(process, 'exit')
+        .mockImplementation(() => {});
+
+      await discoverer.main();
+
+      expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+      if (originalToken !== undefined) {
+        process.env.NPM_TOKEN = originalToken;
+      } else {
+        delete process.env.NPM_TOKEN;
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // checkForUpdates -- retry when all revisions failed (FIX 2)
+  // ─────────────────────────────────────────────────────────────────
+  describe('checkForUpdates -- retry on all-failed revisions', () => {
+    let temporaryDirectory2;
+
+    beforeEach(async () => {
+      temporaryDirectory2 = await fsPromises.mkdtemp(
+        pathModule.default.join(os.default.tmpdir(), 'depup-chk2-'),
+      );
+    });
+
+    afterEach(async () => {
+      await fsPromises.rm(temporaryDirectory2, { force: true, recursive: true });
+    });
+
+    it('retries when version key exists but all revisions have status failed', async () => {
+      const integrityFile = pathModule.default.join(temporaryDirectory2, 'integrity.json');
+      await fsPromises.writeFile(
+        integrityFile,
+        JSON.stringify({
+          '1.0.0': { 'rev-1': { status: 'failed' }, 'rev-2': { status: 'failed' } },
+        }),
+      );
+      const pkg = { name: 'retry-pkg', version: '1.0.0' };
+      const createSpy = jestInstance
+        .spyOn(discoverer, 'createNewPackage')
+        .mockResolvedValueOnce();
+
+      await discoverer.checkForUpdates(pkg, temporaryDirectory2, integrityFile);
+
+      expect(createSpy).toHaveBeenCalledWith(pkg, temporaryDirectory2, '1.0.0');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('only failed revisions'),
+      );
+    });
+
+    it('treats as up-to-date when at least one revision has status published', async () => {
+      const integrityFile = pathModule.default.join(temporaryDirectory2, 'integrity.json');
+      await fsPromises.writeFile(
+        integrityFile,
+        JSON.stringify({
+          '1.0.0': {
+            'rev-1': { status: 'failed' },
+            'rev-2': { status: 'published' },
+          },
+        }),
+      );
+      const pkg = { name: 'ok-pkg', version: '1.0.0' };
+      const createSpy = jestInstance
+        .spyOn(discoverer, 'createNewPackage')
+        .mockResolvedValueOnce();
+
+      await discoverer.checkForUpdates(pkg, temporaryDirectory2, integrityFile);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('up to date'),
+      );
+    });
+
+    it('retries when versionEntry is a non-object scalar (no published revisions)', async () => {
+      const integrityFile = pathModule.default.join(temporaryDirectory2, 'integrity.json');
+      // Shape where the version key maps to a non-object value (old/corrupt data)
+      await fsPromises.writeFile(
+        integrityFile,
+        JSON.stringify({ '1.0.0': 'old-format' }),
+      );
+      const pkg = { name: 'old-fmt-pkg', version: '1.0.0' };
+      const createSpy = jestInstance
+        .spyOn(discoverer, 'createNewPackage')
+        .mockResolvedValueOnce();
+
+      await discoverer.checkForUpdates(pkg, temporaryDirectory2, integrityFile);
+
+      // Non-object versionEntry → hasPublished = false → treated as "only failed" → retry
+      expect(createSpy).toHaveBeenCalledWith(pkg, temporaryDirectory2, '1.0.0');
     });
   });
 })

--- a/scripts/cron-discover.mjs
+++ b/scripts/cron-discover.mjs
@@ -99,6 +99,9 @@ class PackageDiscoverer {
       const { failedPackages, processedPackages } =
         await this.processBatches(packagesToProcess);
 
+      const attempted = processedPackages.length + failedPackages.length;
+      const skipped = packagesToProcess.length - attempted;
+
       console.log(chalk.green(`\n✅ Discovery completed`));
       console.log(
         chalk.cyan(`Processed: ${processedPackages.length} packages`),
@@ -117,6 +120,20 @@ class PackageDiscoverer {
           console.log(chalk.gray(`  - ${package_.name}: ${package_.error}`));
         }
       }
+
+      // Systemic failure detection: >50% failure rate on 10+ attempts signals
+      // a dead NPM_TOKEN or registry outage rather than individual package bugs
+      if (attempted >= 10 && failedPackages.length / attempted > 0.5) {
+        console.error(
+          `SYSTEMIC FAILURE: ${failedPackages.length}/${attempted} packages failed (>${Math.round((failedPackages.length / attempted) * 100)}%). Possible dead NPM_TOKEN or registry outage.`,
+        );
+        process.exit(1);
+      }
+
+      // Machine-readable summary for GitHub step summary (FIX 6)
+      console.log(
+        `DEPUP_SUMMARY processed=${processedPackages.length} failed=${failedPackages.length} skipped=${skipped}`,
+      );
     } catch (error) {
       spinner.fail('Discovery failed');
       console.error(chalk.red('Error:'), error.message);
@@ -331,7 +348,32 @@ class PackageDiscoverer {
 
       // Check if we have this version (use `in` to handle null/falsy entries)
       if (latestVersion in integrityData) {
-        console.log(`  ✅ ${package_.name} is up to date`);
+        // Version key exists -- but only treat as up-to-date if at least one
+        // revision has status === 'published'. If every revision failed, the
+        // publish never actually landed, so we must retry.
+        const versionEntry = integrityData[latestVersion];
+        const hasPublished =
+          versionEntry !== null &&
+          typeof versionEntry === 'object' &&
+          !Array.isArray(versionEntry) &&
+          Object.values(versionEntry).some(
+            (rev) =>
+              rev !== null &&
+              typeof rev === 'object' &&
+              rev.status === 'published',
+          );
+        if (hasPublished) {
+          console.log(`  ✅ ${package_.name} is up to date`);
+        } else {
+          console.log(
+            `  🔄 ${package_.name}@${latestVersion} has only failed revisions — retrying`,
+          );
+          await this.createNewPackage(
+            package_,
+            packageDirectory,
+            latestVersion,
+          );
+        }
       } else {
         console.log(`  🔄 New version available: ${latestVersion}`);
         await this.createNewPackage(package_, packageDirectory, latestVersion);

--- a/scripts/cron-sync.mjs
+++ b/scripts/cron-sync.mjs
@@ -13,75 +13,107 @@ import {
 } from './utilities.mjs';
 
 class PackageSyncer {
+  async processBatches(packagesToProcess) {
+    const syncedPackages = [];
+    let failedCount = 0;
+    let skippedCount = 0;
+
+    for (
+      let index = 0;
+      index < packagesToProcess.length;
+      index += this.concurrentPackages
+    ) {
+      const batch = packagesToProcess.slice(
+        index,
+        index + this.concurrentPackages,
+      );
+      console.log(
+        `Processing batch ${Math.floor(index / this.concurrentPackages) + 1} (${batch.length} packages)...`,
+      );
+
+      const batchResults = await Promise.allSettled(
+        batch.map(async (package_) => {
+          try {
+            console.log(`Syncing ${package_.name}...`);
+            const synced = await this.syncPackage(package_);
+            return {
+              name: package_.name,
+              skipped: !synced,
+              success: true,
+              synced,
+            };
+          } catch (error) {
+            console.warn(`Failed to sync ${package_.name}:`, error.message);
+            return {
+              error: error.message,
+              name: package_.name,
+              skipped: false,
+              success: false,
+              synced: false,
+            };
+          }
+        }),
+      );
+
+      for (const result of batchResults) {
+        if (result.status === 'fulfilled') {
+          if (result.value.synced) {
+            syncedPackages.push(result.value.name);
+          } else if (result.value.success && result.value.skipped) {
+            skippedCount++;
+          } else if (!result.value.success) {
+            failedCount++;
+          }
+        } else if (result.status === 'rejected') {
+          failedCount++;
+          console.warn(
+            `Sync failed: ${result.reason?.message || 'Unknown error'}`,
+          );
+        }
+      }
+
+      if (index + this.concurrentPackages < packagesToProcess.length) {
+        await sleep(this.rateLimitDelay);
+      }
+    }
+
+    return { failedCount, skippedCount, syncedPackages };
+  }
+
   async main() {
     console.log('🔄 Starting package sync...');
 
     try {
-      // Get all existing packages
       const existingPackages = await this.getExistingPackages();
       console.log(`Found ${existingPackages.length} existing packages`);
 
-      // Process packages in parallel batches
       const packagesToProcess = existingPackages.slice(
         0,
         this.maxPackagesPerRun,
       );
-      const syncedPackages = [];
-
-      // Process in batches to avoid overwhelming the system
-      for (
-        let index = 0;
-        index < packagesToProcess.length;
-        index += this.concurrentPackages
-      ) {
-        const batch = packagesToProcess.slice(
-          index,
-          index + this.concurrentPackages,
-        );
-        console.log(
-          `Processing batch ${Math.floor(index / this.concurrentPackages) + 1} (${batch.length} packages)...`,
-        );
-
-        // Process batch in parallel
-        const batchResults = await Promise.allSettled(
-          batch.map(async (package_) => {
-            try {
-              console.log(`Syncing ${package_.name}...`);
-              const synced = await this.syncPackage(package_);
-              return { name: package_.name, success: true, synced };
-            } catch (error) {
-              console.warn(`Failed to sync ${package_.name}:`, error.message);
-              return {
-                error: error.message,
-                name: package_.name,
-                success: false,
-                synced: false,
-              };
-            }
-          }),
-        );
-
-        // Collect successful syncs
-        for (const result of batchResults) {
-          if (result.status === 'fulfilled' && result.value.synced) {
-            syncedPackages.push(result.value.name);
-          } else if (result.status === 'rejected') {
-            console.warn(
-              `Sync failed: ${result.reason?.message || 'Unknown error'}`,
-            );
-          }
-        }
-
-        // Rate limiting between batches (not between individual packages)
-        if (index + this.concurrentPackages < packagesToProcess.length) {
-          await sleep(this.rateLimitDelay);
-        }
-      }
+      const { failedCount, skippedCount, syncedPackages } =
+        await this.processBatches(packagesToProcess);
 
       console.log(`✅ Synced ${syncedPackages.length} packages`);
       if (syncedPackages.length > 0) {
         console.log('Synced packages:', syncedPackages.join(', '));
       }
+
+      const attemptedCount = syncedPackages.length + failedCount;
+
+      // Systemic failure detection: >50% failure rate on 10+ attempts signals a
+      // dead NPM_TOKEN or registry outage rather than individual package failures
+      if (attemptedCount >= 10 && failedCount / attemptedCount > 0.5) {
+        console.error(
+          `SYSTEMIC FAILURE: ${failedCount}/${attemptedCount} packages failed (>${Math.round((failedCount / attemptedCount) * 100)}%). Possible dead NPM_TOKEN or registry outage.`,
+        );
+        process.exit(1);
+      }
+
+      // Machine-readable summary for GitHub step summary (FIX 6)
+      console.log(
+        `DEPUP_SUMMARY processed=${syncedPackages.length} failed=${failedCount} skipped=${skippedCount}`,
+      );
     } catch (error) {
       console.error('Sync failed:', error.message);
       process.exit(1);
@@ -186,6 +218,21 @@ class PackageSyncer {
         await this.generateReadme(package_.name);
         return true;
       }
+
+      // Even if version matches, check whether the current version only has
+      // failed revisions -- meaning the publish never actually landed.
+      // If so, re-process rather than treating it as up-to-date.
+      if (
+        this.hasOnlyFailedRevisions(package_.integrityData, package_.version)
+      ) {
+        console.log(
+          `  🔄 ${package_.name}@${package_.version} has only failed revisions — retrying`,
+        );
+        await this.updatePackage(package_, package_.version);
+        await this.generateReadme(package_.name);
+        return true;
+      }
+
       // Check if dependencies need updating
       const needsDependencyUpdate = await this.checkDependencyUpdates(package_);
       if (needsDependencyUpdate) {
@@ -419,6 +466,32 @@ class PackageSyncer {
       diff === 'minor' ||
       diff === 'premajor' ||
       diff === 'preminor'
+    );
+  }
+
+  hasOnlyFailedRevisions(integrityData, version) {
+    if (
+      !integrityData ||
+      typeof integrityData !== 'object' ||
+      !(version in integrityData)
+    ) {
+      return false;
+    }
+    const versionEntry = integrityData[version];
+    if (
+      versionEntry === null ||
+      typeof versionEntry !== 'object' ||
+      Array.isArray(versionEntry)
+    ) {
+      return false;
+    }
+    const revisions = Object.values(versionEntry);
+    if (revisions.length === 0) {
+      return false;
+    }
+    return !revisions.some(
+      (rev) =>
+        rev !== null && typeof rev === 'object' && rev.status === 'published',
     );
   }
 


### PR DESCRIPTION
## Summary
Hardens depup's autonomous loops so the engine truly runs itself. From a verified robustness audit. Six fixes:

**CRITICAL**
1. Honest publish failures (process-package-request.yml): the publish step swallowed failures with a || block, so a failed publish still posted a false 'Package published' comment and closed the issue while nothing reached npm. Now the failure propagates; an if: failure()-guarded step persists the submission to user-packages.json so cron auto-retries, the comment honestly says 'queued for automatic retry', and the issue stays open. GPG import made if: always() so the retry commit can sign; queue step guarded to fire only for genuinely valid, new packages (npm-info success + not-duplicate), not validation rejections.
2. Failed packages now retried (cron-discover.mjs, cron-sync.mjs): a version whose only revisions are status=failed was treated as up-to-date forever. Both loops now re-process unless at least one revision is published.

**HIGH**
3. Duplicate check now also covers config/curated-packages.json + config/user-packages.json (was only the hardcoded fallback list + packages/ dir).
4. refresh-list.yml: added concurrency group, timeout, and a rebase-retry push loop (was a bare push → silent staleness).

**MED**
5. Systemic-failure detection: if >50% of 10+ attempted packages fail in a shard (e.g. dead NPM_TOKEN), the shard exits 1 visibly instead of a green-but-empty run.
6. Observability: scripts emit a DEPUP_SUMMARY counts line surfaced into the GitHub step summary.

## Test Plan
- 947 unit tests pass; new tests cover both retry-on-failed-revision branches, the systemic-failure threshold (fires / doesn't-fire under 10), hasOnlyFailedRevisions guards, DEPUP_SUMMARY emission.
- Coverage gate holds: changed scripts >=80/80 (cron-discover 96.8/94.2, cron-sync 95.7/91.5).
- lint 0 errors; npm audit 0; workflow YAML validated.