### PR TITLE
chore: audit own deps — bump semver to 7.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "npm-registry-fetch": "20.0.1",
         "ora": "9.4.0",
         "pacote": "21.5.0",
-        "semver": "7.8.2"
+        "semver": "7.8.3"
       },
       "devDependencies": {
         "eslint": "10.4.1",
@@ -11592,9 +11592,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "npm-registry-fetch": "20.0.1",
     "ora": "9.4.0",
     "pacote": "21.5.0",
-    "semver": "7.8.2"
+    "semver": "7.8.3"
   },
   "devDependencies": {
     "eslint": "10.4.1",


### PR DESCRIPTION
## Summary

- `npm audit`: 0 vulnerabilities — nothing to fix for security
- Bumped `semver` from `7.8.2` to `7.8.3` (patch, exact-pinned in dependencies)
- `stylelint` 16.26.1 → 17.x intentionally skipped: mikey-pro 10.3.x requires `stylelint@^16` as a peer dep; bumping to 17 breaks `npm ci`

## Test Plan

- [x] `npm install` regenerated lockfile (changed 1 package)
- [x] `npm ci` succeeded — only the known-benign ERESOLVE peer warnings from mikey-pro 10.3.x; 0 vulnerabilities; 882 packages installed
- [x] `npm test` — **947 tests passed, 0 failed** (5 suites: unit + integration)
- [x] `npm run lint` — clean, 0 errors
- [x] Diff is exactly `package.json` + `package-lock.json` — no other files touched
- [x] `semver` pinned exact (`7.8.3`, no caret)
- [x] `stylelint` left at `16.26.1`