### PR TITLE
fix: harden security subsystem against silent-failure / fail-open bugs

### DIFF
--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -1987,18 +1987,14 @@ describe('securityScanner coverage gaps', () => {
       );
     });
 
-    it('returns empty array when getAllFiles throws', async () => {
+    it('throws when getAllFiles throws (fail-closed: broken scan must not report clean)', async () => {
       jestInstance
         .spyOn(scanner, 'getAllFiles')
         .mockRejectedValueOnce(new Error('permission denied'));
-      const findings =
-        await scanner.performAdvancedMalwareChecks(temporaryDirectory);
 
-      expect(findings).toStrictEqual([]);
-      expect(console.warn).toHaveBeenCalledWith(
-        'Advanced malware check failed:',
-        'permission denied',
-      );
+      await expect(
+        scanner.performAdvancedMalwareChecks(temporaryDirectory),
+      ).rejects.toThrow('Advanced malware check failed: permission denied');
     });
 
     it('detects multiple suspicious items in one scan', async () => {
@@ -3486,8 +3482,42 @@ describe('secureDepUp coverage gaps', () => {
   });
 
   describe('runSnykScan', () => {
-    it('does not throw when snyk is not available', () => {
+    it('does not throw when snyk is not available (ENOENT)', () => {
+      // On this machine snyk is not installed -- spawnSnyk throws ENOENT which
+      // is caught and treated as graceful degradation (tool not present)
       expect(() => secure.runSnykScan('/nonexistent/path')).not.toThrow();
+    });
+
+    it('throws "Snyk found vulnerabilities" when snyk exits status 1', () => {
+      // Spy on spawnSnyk to simulate snyk finding vulnerabilities (exit 1)
+      const vulnError = new Error('snyk found issues');
+      vulnError.status = 1;
+      vulnError.code = undefined;
+      jest.spyOn(secure, 'spawnSnyk').mockImplementationOnce(() => {
+        throw vulnError;
+      });
+
+      expect(() => secure.runSnykScan('/some/path')).toThrow(
+        'Snyk found vulnerabilities',
+      );
+
+      jest.restoreAllMocks();
+    });
+
+    it('throws "Snyk scan failed unexpectedly" on non-ENOENT non-1 error', () => {
+      // Spy on spawnSnyk to simulate a crash/timeout (not ENOENT, not exit 1)
+      const crashError = new Error('process timed out');
+      crashError.code = 'ETIMEDOUT';
+      crashError.status = undefined;
+      jest.spyOn(secure, 'spawnSnyk').mockImplementationOnce(() => {
+        throw crashError;
+      });
+
+      expect(() => secure.runSnykScan('/some/path')).toThrow(
+        'Snyk scan failed unexpectedly',
+      );
+
+      jest.restoreAllMocks();
     });
   });
 
@@ -4270,13 +4300,12 @@ describe('securityApprovalWorkflow coverage gaps', () => {
       expect(result.allowlisted).toStrictEqual([]);
     });
 
-    it('returns default version when file contains malformed JSON', async () => {
+    it('throws when file contains malformed JSON (non-ENOENT errors must not silently return empty allowlist)', async () => {
       await fs.writeFile(workflow.allowlistPath, 'not-valid-json');
 
-      const result = await workflow.loadAllowlist();
-
-      expect(result.version).toBe('1.0.0');
-      expect(result.allowlisted).toStrictEqual([]);
+      await expect(workflow.loadAllowlist()).rejects.toThrow(
+        'Failed to load allowlist',
+      );
     });
   });
 

--- a/scripts/depup-security.mjs
+++ b/scripts/depup-security.mjs
@@ -326,17 +326,35 @@ class SecureDepUp {
     }
   }
 
+  spawnSnyk(packagePath) {
+    execFileSync('snyk', ['test', '--severity-threshold=high'], {
+      cwd: packagePath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 120_000,
+    });
+  }
+
   runSnykScan(packagePath) {
     try {
-      execFileSync('snyk', ['test', '--severity-threshold=high'], {
-        cwd: packagePath,
-        encoding: 'utf8',
-        stdio: 'pipe',
-        timeout: 120_000,
+      this.spawnSnyk(packagePath);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        // Snyk not installed in this environment -- acceptable degradation
+        console.warn(chalk.yellow('Snyk scan skipped (not installed)'));
+        return;
+      }
+      if (error.status === 1) {
+        // Snyk exited 1 = vulnerabilities found -- propagate as a real failure
+        throw new Error(`Snyk found vulnerabilities: ${error.message}`, {
+          cause: error,
+        });
+      }
+      // Any other failure (crash, timeout, network) -- propagate so the
+      // vulnerability scan does not silently record as "completed"
+      throw new Error(`Snyk scan failed unexpectedly: ${error.message}`, {
+        cause: error,
       });
-    } catch {
-      // Snyk may not be installed in all environments -- non-fatal
-      console.warn(chalk.yellow('Snyk scan skipped or unavailable'));
     }
   }
 

--- a/scripts/security-approval.mjs
+++ b/scripts/security-approval.mjs
@@ -422,8 +422,18 @@ class SecurityApprovalWorkflow {
       }
 
       return parsed;
-    } catch {
-      return { allowlisted: [], version: '1.0.0' };
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        // File does not exist yet -- return empty allowlist (first-run case)
+        return { allowlisted: [], version: '1.0.0' };
+      }
+      // Any other error (permission denied, corrupt file, parse error) must propagate.
+      // Swallowing I/O errors here was fail-open for the admin tool: a read failure
+      // during approvePackage would cause the entire existing allowlist to be
+      // silently overwritten with only the newly approved package.
+      throw new Error(`Failed to load allowlist: ${error.message}`, {
+        cause: error,
+      });
     }
   }
 

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -262,8 +262,11 @@ class SecurityScanner {
 
       return findings;
     } catch (error) {
-      console.warn('Advanced malware check failed:', error.message);
-      return [];
+      // Re-throw so the outer performMalwareScan sets status:'error' and rethrows.
+      // Returning [] here was fail-open: a broken check would silently report "clean".
+      throw new Error(`Advanced malware check failed: ${error.message}`, {
+        cause: error,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Audits and hardens the three security-subsystem scripts against the same class of silent-failure bugs fixed in the main pipeline (#1254). This is the untrusted-package security path — every fix converts a **fail-open** behavior (error/missing-data silently treated as "clean/approved") into **fail-closed** (error propagates, package is not allowed through).

### Bugs fixed

1. **`security-scan.mjs` — advanced malware check fail-open.** A throw during the advanced pattern scan was caught and returned `[]` (no findings), so a broken malware check produced the same result as "clean." Now re-throws with `{ cause }` so the outer scan records `status:'error'`.

2. **`depup-security.mjs` — Snyk scan swallowed all failures.** Bare `catch {}` treated tool-not-installed, vulnerabilities-found (exit 1), and crash/timeout identically as "skip." A crashed/timed-out scan silently recorded as completed. Now distinguishes ENOENT (graceful skip) from exit-1 (vulns → throw) from any other error (crash/timeout → throw). Extracted a `spawnSnyk` seam for testability.

3. **`security-approval.mjs` — allowlist load fail-open.** Bare `catch {}` returned an empty allowlist for *all* read errors. A transient I/O/parse error during approval would silently overwrite the entire existing allowlist with a single entry. Now only ENOENT (first-run) returns empty; all other errors propagate.

## Test Plan

- 935 unit tests pass (`npm run test:unit`), including new/updated tests asserting the fail-closed behavior for all three fixes.
- `npm run lint`: 0 errors.
- Per-file coverage (≥80/80 threshold enforced by `jest.config.cjs`): security-scan 83.0/81.0, depup-security 81.9/83.0, security-approval 91.9/89.1 (line/branch).