### PR TITLE
fix: harden GitHub Actions workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,6 +10,10 @@ on:
       - 'CONTRIBUTING.md'
   workflow_dispatch: {}
 
+# Commits synced package data and pushes to main
+permissions:
+  contents: write
+
 concurrency:
   group: depup-sync-${{ github.ref }}
   cancel-in-progress: false
@@ -26,12 +30,12 @@ jobs:
        github.event.head_commit.author.name != 'github-actions[bot]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         default: false
 
+# All three jobs commit package data and push to main
+permissions:
+  contents: write
+
 concurrency:
   group: depup-cron
   cancel-in-progress: false
@@ -33,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -165,13 +169,13 @@ jobs:
 
     steps:
       - name: Checkout (latest main, including discover pushes)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -287,13 +291,13 @@ jobs:
 
     steps:
       - name: Checkout (latest main after all syncs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/depup-secure.yml
+++ b/.github/workflows/depup-secure.yml
@@ -33,6 +33,11 @@ on:
         type: boolean
         default: true
 
+# Default read-only; only the secure-processing job (which commits package
+# data and pushes to main) is granted contents: write at the job level.
+permissions:
+  contents: read
+
 concurrency:
   group: depup-secure-${{ inputs.package }}
   cancel-in-progress: false
@@ -63,12 +68,15 @@ jobs:
           echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # This job npm-installs the (untrusted) package under analysis --
+          # never leave the repo token on disk where install scripts could read it
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -191,7 +199,7 @@ jobs:
           fi
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: security-reports-${{ steps.sanitize.outputs.safe_name || needs.security-validation.outputs.package_safe }}
           path: security-reports/
@@ -229,13 +237,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build security sandbox
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -245,7 +255,7 @@ jobs:
           outputs: type=docker,dest=/tmp/depup-sandbox.tar
 
       - name: Upload container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: depup-security-sandbox
           path: /tmp/depup-sandbox.tar
@@ -256,15 +266,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [security-validation, container-build]
     timeout-minutes: 45
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Download security container
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: depup-security-sandbox
           path: /tmp/
@@ -406,7 +418,7 @@ jobs:
           fi
 
       - name: Upload processing reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: processing-reports-${{ needs.security-validation.outputs.package_safe }}
           path: security-reports/
@@ -421,11 +433,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Download all reports
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: "*-${{ needs.security-validation.outputs.package_safe }}"
           path: final-reports/
@@ -506,7 +520,7 @@ jobs:
           fi
 
       - name: Upload final report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: final-security-report-${{ needs.security-validation.outputs.package_safe }}
           path: final-reports/

--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         default: false
 
+# Commits processed package data and pushes to main
+permissions:
+  contents: write
+
 concurrency:
   group: depup-${{ github.workflow }}-${{ inputs.package }}
   cancel-in-progress: false
@@ -39,12 +43,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
 
+# Read-only: measures performance and uploads artifacts, never pushes
+permissions:
+  contents: read
+
 jobs:
   performance-test:
     name: Performance Test
@@ -18,12 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -104,7 +109,7 @@ jobs:
 
       - name: Upload performance artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: performance-metrics
           path: |
@@ -139,12 +144,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/process-package-request.yml
+++ b/.github/workflows/process-package-request.yml
@@ -4,6 +4,11 @@ on:
   issues:
     types: [labeled]
 
+# contents: write -- checkout + push of package data to main.
+# Issue comments and closing use BOT_PAT, not GITHUB_TOKEN, so no issues scope.
+permissions:
+  contents: write
+
 concurrency:
   group: process-package-${{ github.event.issue.number }}
   cancel-in-progress: true
@@ -19,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -35,7 +40,7 @@ jobs:
 
       - name: Parse Issue Content
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const issueBody = context.payload.issue.body || '';
@@ -319,7 +324,7 @@ jobs:
 
       - name: Comment on Issue
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           CHECK_EXISTS: ${{ steps.check-existing.outputs.exists }}
           JOB_STATUS: ${{ job.status }}
@@ -401,7 +406,7 @@ jobs:
 
       - name: Close Issue on Success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
@@ -414,7 +419,7 @@ jobs:
 
       - name: Close Issue if Duplicate
         if: always() && steps.check-existing.outputs.exists == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |

--- a/.github/workflows/refresh-list.yml
+++ b/.github/workflows/refresh-list.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ on:
       - 'jest.config.cjs'
       - '.github/workflows/test.yml'
 
+# Read-only: runs tests, never pushes
+permissions:
+  contents: read
+
 concurrency:
   group: depup-test-${{ github.ref }}
   cancel-in-progress: true
@@ -33,10 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
## Summary

depup is a public repo whose workflows hold `NPM_TOKEN` (publish rights for 1000+ @depup packages), `GPG_PRIVATE_KEY`, and `BOT_PAT` — the workflow files are the highest-value attack surface. This PR hardens all 8 workflows in place (no migration, per the standing GitHub-canonical decision).

### 1. Least-privilege permissions (was: repo default on 7 of 8 workflows)

| Workflow | Permissions | Rationale |
|---|---|---|
| cron.yml | `contents: write` (top) | all 3 jobs push package data to main |
| process-package-request.yml | `contents: write` (top) | checkout + push; issue comments/close use BOT_PAT, so no `issues` scope on GITHUB_TOKEN |
| bump.yml | `contents: write` (top) | pushes synced package data |
| refresh-list.yml | `contents: write` (job, pre-existing) | unchanged |
| depup.yml | `contents: write` (top) | pushes processed package data |
| depup-secure.yml | `contents: read` (top), `contents: write` on secure-processing job only | validation/container/report jobs never push |
| performance.yml | `contents: read` (top) | artifacts only |
| test.yml | `contents: read` (top) | tests only |

### 2. All actions pinned to full commit SHAs (38 refs, 7 distinct actions)

Resolved live from each repo's tags (annotated tags dereferenced to commits):

- `actions/checkout` 34e114876b0b11c390a56381ad16ebd13914f8d5 (v4.3.1)
- `actions/setup-node` 49933ea5288caeca8642d1e84afbd3f7d6820020 (v4.4.0)
- `actions/github-script` f28e40c7f34bde8b3046d885e986cb6290c5673b (v7.1.0)
- `actions/upload-artifact` ea165f8d65b6e75b540449e92b4886f43607fa02 (v4.6.2)
- `actions/download-artifact` d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4.3.0)
- `docker/setup-buildx-action` 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f (v3.12.0)
- `docker/build-push-action` ca052bb54ab0790a636c9b5f226502c73d547a25 (v5.4.0)

A mutable tag on a compromised action repo can no longer swap code under these workflows.

### 3. Credential persistence disabled where jobs never push

`persist-credentials: false` added to checkouts in: test.yml, performance.yml (both jobs), depup-secure.yml security-validation / container-build / final-validation. The security-validation job `npm install`s the untrusted package under analysis — previously the default-persisted GITHUB_TOKEN sat in `.git/config` where any install script could read it. Push-capable jobs keep credentials (required).

### 4. Injection review of the issue-triggered path (process-package-request.yml)

Untrusted inputs: `github.event.issue.title` and `.body` (any GitHub user can open an issue; the workflow fires when the `package-request` label is applied).

- **Parse step** runs in `actions/github-script` (JavaScript — no shell interpolation). The extracted package name is validated against `^(@?[a-zA-Z0-9._/-]+)$` and the step hard-fails BEFORE any output is set if it contains characters outside that allowlist. No shell metacharacters, spaces, backticks, `$`, or quotes can pass.
- **Every downstream `run:` step** consumes the name via `env:` indirection (`$PACKAGE_NAME`, quoted) — there is no direct `${{ steps.parse.outputs.* }}`, `${{ github.event.issue.title }}`, or `${{ github.event.issue.body }}` interpolation inside any `run:` block. Verified by grep across the file.
- Secondary shell-side validation re-checks the format (`^(@[a-zA-Z0-9._-]+/)?[a-zA-Z0-9._-]+$`) before use.
- `package_url` / `reasoning` outputs are extracted but never consumed by any step — inert.
- Concurrency group interpolates only `github.event.issue.number` (numeric).
- Secrets exposed to this path (`NPM_TOKEN`, `GPG_PRIVATE_KEY`, `BOT_PAT`) are reachable only after the character-allowlist gate.

### 5. No pull_request_target

Verified: no workflow uses `pull_request_target` or checks out PR head refs with secrets in scope. Triggers are `schedule`, `workflow_dispatch`, `push` (main), `pull_request` (test.yml, read-only token), and `issues: labeled` (reviewed above).

## Validation

`yaml.safe_load` on all 8 files:

```
.github/workflows/bump.yml: OK perms={'contents': 'write'}
.github/workflows/cron.yml: OK perms={'contents': 'write'}
.github/workflows/depup-secure.yml: OK perms={'contents': 'read'} job={'secure-processing': {'contents': 'write'}}
.github/workflows/depup.yml: OK perms={'contents': 'write'}
.github/workflows/performance.yml: OK perms={'contents': 'read'}
.github/workflows/process-package-request.yml: OK perms={'contents': 'write'}
.github/workflows/refresh-list.yml: OK job={'refresh': {'contents': 'write'}}
.github/workflows/test.yml: OK perms={'contents': 'read'}
```

`actionlint` (with shellcheck): findings identical to main — only pre-existing info-level SC2086 notes, nothing introduced:

```
actionlint: no new findings vs main
```

Pin completeness: `grep -rn '@v[0-9]' .github/workflows/` returns nothing — no tag-pinned actions remain.

Manual-dispatch dry run deferred until after merge: workflows run from main's definition for `workflow_dispatch`/`schedule`, so the hardened versions only become exercisable post-merge. First post-merge cron cycle (every 8h) will validate cron.yml under the new permissions; depup.yml can be dispatched with `publish: false` as a no-risk smoke test.

## Environment note: git-push stall workaround (recurring)

`git push` from the local dev environment stalled silently (no output, no remote ref created) — second confirmed occurrence this week (first: PR #1251). Workaround, now standard for this environment: push the commit via the GitHub Git Data API with `gh api` (create blobs -> tree on latest main -> commit -> ref). Two gotchas baked into the procedure:

1. Use the canonical repo slug `chiefmikey/depup` — the `depup/npm` alias answers GETs but 307-redirects JSON POSTs, which `gh api --input` does not re-send, yielding empty tree/commit SHAs.
2. Base the tree on the latest remote main at push time (cron shards advance main every 8h); safe whenever the commit touches disjoint paths.

Remote content was verified file-by-file against the local commit after push. Also recorded in project memory.