### PR TITLE
chore: add Dependabot config for GitHub Actions SHA-pin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` targeting the `github-actions` ecosystem
- All 7 action slugs (`actions/checkout`, `actions/setup-node`, `actions/github-script`, `actions/upload-artifact`, `actions/download-artifact`, `docker/setup-buildx-action`, `docker/build-push-action`) are covered by a single wildcard group — all 38 SHA-pinned refs across 8 workflows get updates via one weekly grouped PR
- Dependabot natively updates both the SHA and the trailing `# vX.Y.Z` comment when the action is pinned to a SHA (which all 8 workflows already are after PR #1257)
- Commit prefix set to `chore` to match the repo's conventional commit convention

## Test Plan

- [ ] YAML parses cleanly (`python3 -c "import yaml,sys; yaml.safe_load(open('.github/dependabot.yml')); print('YAML OK')"` → `YAML OK`)
- [ ] Dependabot becomes active in the repo's Insights → Dependency graph → Dependabot tab after merge
- [ ] First weekly run produces a single grouped PR covering all action bumps (not one-per-action)