### PR TITLE
chore: reduce cron cadence 8h->12h to cut CI minute burn (~33%)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,10 @@ name: "Automated Discovery & Sync"
 
 on:
   schedule:
-    - cron: "0 */8 * * *"
+    # Every 12h (was 8h). Twice-daily re-bump keeps dependency-update freshness
+    # within ~12h while cutting CI minute burn ~33%. User submissions publish
+    # immediately via process-package-request.yml and are unaffected by cadence.
+    - cron: "0 */12 * * *"
   workflow_dispatch:
     inputs:
       discover_only:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: "Unit Tests"
 
 # Runs the unit suite (no integration tests — those hit the live npm registry).
-# Scoped to source paths so the every-8h De Pup package-data commits do not
+# Scoped to source paths so the every-12h De Pup package-data commits do not
 # trigger redundant test runs.
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # DepUp -- Project CLAUDE.md
 
 ## Project Overview
-Automated npm package factory. Downloads npm packages, bumps all dependencies to latest, tests, publishes as `@depup/package-name`. 1000+ packages managed, processed every 8 hours, user submissions publish immediately.
+Automated npm package factory. Downloads npm packages, bumps all dependencies to latest, tests, publishes as `@depup/package-name`. 1000+ packages managed, processed every 12 hours, user submissions publish immediately.
 
 ## Tech Stack
 - **Runtime:** Node.js 24 LTS, ESM (`"type": "module"`)
@@ -34,7 +34,7 @@ config/
   user-packages.json     # User-submitted packages (via GitHub issues)
   security-allowlist.json
 .github/workflows/
-  cron.yml               # Every 8h: discover + sync (3 shards) + heal
+  cron.yml               # Every 12h: discover + sync (3 shards) + heal
   process-package-request.yml # Issue-triggered: validate, publish, commit, close
   refresh-list.yml       # Weekly: refresh curated list from npm popularity
   bump.yml               # On push: re-sync (skips De Pup commits)
@@ -68,7 +68,7 @@ npm run heal                # Self-healing repairs
 6. Trigger: `labeled` only (not `opened` -- prevents duplicate runs)
 
 ## Cron Architecture
-- **Every 8h:** discover (curated + user lists) + sync (dep bump check) + heal
+- **Every 12h:** discover (curated + user lists) + sync (dep bump check) + heal
 - **3 shards** parallel, 5 concurrent packages per shard (async child processes)
 - **Weekly:** refresh curated list from npm search API (1000 packages)
 - **Dep checking:** batches of 10, abort-on-first-match, minor/major only

--- a/docs/handoff/2026-06-10-dependabot-actions.md
+++ b/docs/handoff/2026-06-10-dependabot-actions.md
@@ -1,0 +1,56 @@
+# Handoff: Dependabot config for GitHub Actions SHA-pin updates
+
+_Status: COMPLETED_
+_Date: 2026-06-10_
+_Branch: chore/dependabot-actions (merged + deleted)_
+
+## What shipped
+
+PR #1258 squash-merged to main — **merge SHA `439f3966416867c93c657916d5425608f448c596`** (verified/signed badge).
+
+Closes the maintenance gap flagged in the 2026-06-10 workflow-hardening handoff: PR #1257 SHA-pinned all 38 action refs across the workflows but left **no automated mechanism** to keep those pins fresh, so they would silently go stale (a security regression over time).
+
+Added `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+```
+
+## Decisions & rationale
+
+- **Dependabot over Renovate** — GitHub-native, no GitHub App install required for the public repo. Dependabot natively updates a SHA pin and its trailing `# vX.Y.Z` comment when the action source is SHA-pinned. Renovate would have added an external dependency.
+- **`directory: "/"`** — the `github-actions` ecosystem scans `.github/workflows/` automatically from the repo root; do NOT set `directory: ".github/workflows"`.
+- **Single grouped weekly PR** via `groups.github-actions.patterns: ["*"]` — one PR for all action bumps instead of one-per-action. The wildcard also auto-covers any future action added to a workflow, so no slug can silently go unmanaged.
+- **`commit-message.prefix: chore`** matches the repo's conventional-commit convention. Dependabot opens its PRs under the dependabot bot identity (not "De Pup") — that is expected and correct, no spoofing attempted.
+
+## Coverage confirmed
+
+Haiku enumerated all 8 workflow files. 7 distinct action slugs, all covered by the wildcard:
+`actions/checkout`, `actions/setup-node`, `actions/github-script`, `actions/upload-artifact`, `actions/download-artifact`, `docker/setup-buildx-action`, `docker/build-push-action`.
+(Note: there are 8 workflow files, not the 6 named in CLAUDE.md — `performance.yml` and `test.yml` also exist.)
+
+## Gotchas for the next session
+
+- **A config-only PR triggers NO CI.** `test.yml`'s `pull_request` trigger is path-filtered to `scripts/**`, `package.json`, `package-lock.json`, `jest.config.cjs`, `.github/workflows/test.yml`. A `dependabot.yml`-only change matches none of those, so `gh pr checks` reports "no checks reported" and the PR sits `BLOCKED`. **This is correct, not a failure.** Validate the YAML locally (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml')); print('OK')"`) and merge with `--admin`.
+- **Merge requires `gh pr merge --admin --squash`** — the main ruleset blocks normal merges (see memory `feedback_depup_main_ruleset_admin_merge`).
+- **`git push` stalled again** — the Sonnet worker pushed the branch via the GitHub Git Data API (the standard workaround in this env; see memory `reference_git_push_api_workaround`). Side effect: the local `chore/dependabot-actions` commit (signed) differed from the API-pushed remote commit (`a1c720`, unverified); the squash merge re-signed it on main so main's commit is verified.
+- **Directive correction:** a resume prompt claimed `origin` was `git.wolfe.tools` (not the GitHub mirror). That is false — the only remote is `github.com/chiefmikey/depup`, and GitHub is canonical for depup (gitea/wolfe was decommissioned for this repo). The merge happened on GitHub.
+
+## Context that would be lost
+
+- Memory updated: `MEMORY.md` "Workflow Supply-Chain Hardening (2026-06-10)" section extended with the PR #1258 follow-up bullet (merge SHA, config rationale, the no-CI-on-config-only gotcha, the wolfe-remote correction).
+
+## Follow-ups (none blocking)
+
+- First Dependabot run will open a grouped PR on its weekly cadence; review it like any dependency bump (the action SHAs and version comments will update together). No action needed until then.


### PR DESCRIPTION
## Summary

The April billing audit flagged ~9k Linux min/month against `performance.yml`, but that workflow runs **weekly** and bills **~9 min/month** (two ~35s jobs). The real burn is **`cron.yml`**, which the audit appears to have mis-attributed.

### Measured cron.yml burn (last 30 runs, `gh run view` per-job billed minutes)
- **Average: ~40 billed min/run**; range 12 (quiet) -> 179 (heavy backlog day).
- Heavy run breakdown: 3 discover shards (23-31m each) + 3 sync shards (13-33m each) + heal (1m) = **~120-180 billed min/run**.
- At 3 runs/day -> **~3.6k min/month baseline, trending toward ~9k in heavy months** (the most recent 6 runs were all 111-179 min).

### Why the schedule is the only real lever
Billed minutes = **sum of all job-minutes**, and the package-processing work is fixed for a given run. So:
- **Reducing shard parallelism (3->2) does NOT cut billed minutes** -- 3x25m approximately 2x37m. It only shortens wall-clock and trims a little fixed per-job overhead.
- **Path-scoping does not apply** -- this is a time-cron over the npm ecosystem, not repo-change-triggered.
- **Narrowing the schedule cuts billed minutes linearly.**

## Change
`0 */8 * * *` -> `0 */12 * * *` (3 runs/day -> 2).

## Before / after
| | Runs/day | Avg billed/run | Est. monthly |
|---|---|---|---|
| Before | 3 | ~40 min | ~3.6k (up to ~9k heavy) |
| After | 2 | ~40 min | **~2.4k (up to ~6k heavy)** |

**~33% reduction**, ~1.2k-3k min/month saved.

## Coverage impact: none meaningful
- Dependency re-bumps are still checked **twice daily** (delay of a dep pickup grows from <=8h to <=12h).
- **User submissions are unaffected** -- they publish immediately via `process-package-request.yml` (issue-triggered, cadence-independent).

## Validation
- `yaml.safe_load` clean on `cron.yml` + `test.yml`.
- `actionlint` introduces no new findings (pre-existing info-level SC2086 in the Shard Summary steps, identical to main).
- Docs updated to match (`CLAUDE.md` x3, `test.yml` comment).

Further reduction to daily (`0 6 * * *`, -67%) is available if twice-daily proves more than needed.