### PR TITLE
perf: cut GitHub Actions minutes (daily discover + two-phase sync)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,8 @@ name: "Automated Discovery & Sync"
 
 on:
   schedule:
-    - cron: "0 */8 * * *"
+    - cron: "0 8,16 * * *"  # sync + heal only (skip discover)
+    - cron: "0 0 * * *"     # full pipeline: discover + sync + heal (daily, midnight UTC)
   workflow_dispatch:
     inputs:
       discover_only:
@@ -29,7 +30,7 @@ jobs:
     name: Discover (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: ${{ !inputs.sync_only }}
+    if: ${{ !inputs.sync_only && (github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * *') }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/handoff/2026-06-16-actions-minutes.md
+++ b/docs/handoff/2026-06-16-actions-minutes.md
@@ -1,0 +1,39 @@
+# Handoff: GitHub Actions Minutes Optimization
+
+_Status: COMPLETE (PR open, awaiting merge)_
+_Date: 2026-06-16_
+_Branch: feat/optimize-actions-minutes_
+
+## Goal
+Reduce the documented ~9k GitHub Actions minutes/month burn, optimizing within GitHub Actions (no mikmac/wolfe offload unless the limit is breached).
+
+## What shipped — PR #1263 (OPEN)
+https://github.com/chiefmikey/depup/pull/1263 — commit `988b595f0`, base `main`.
+
+Two complementary changes:
+
+1. **Discover dropped to daily; sync + heal stay every 8h.**
+   - `cron.yml`: replaced single `0 */8 * * *` schedule with two cron lines:
+     - `0 8,16 * * *` — sync + heal only
+     - `0 0 * * *` — full pipeline (discover + sync + heal)
+   - Discover job `if:` gated to `github.event.schedule == '0 0 * * *'` or `workflow_dispatch`.
+   - Sync runs 00/08/16 UTC — **core 8h processing contract unchanged**. Sync/heal `if:` already tolerate a skipped discover (`needs.discover.result == 'skipped'`), so no change there.
+   - Rationale: new packages only enter via the weekly curated-list refresh, or via user submissions that publish immediately through `process-package-request.yml` (bypasses discover). So discover every 8h was ~3x redundant.
+
+2. **Two-phase sync pre-check** in `cron-sync.mjs` (was uncommitted on the branch; verified + folded in).
+   - `processBatches` split into `checkBatches` (cheap network-only pre-check, high concurrency) + `applyBatches` (expensive npm-install+test, concurrency 5, only on packages that need updates).
+
+## Verification
+- `npx jest --runTestsByPath scripts/__tests__/unit.test.js` → 72 cron-sync tests pass (`Tests: 840 skipped, 72 passed, 912 total`). The ~49 refresh-curated-list setTimeout failures on full `npm test` are a known Node-26-only local artifact (CI/Node-24 green) — not chased.
+- `cron.yml` YAML validated (`yaml.safe_load` → OK).
+
+## Projected savings
+**~4,320 min/month (~72h)** — measured, not assumed. 6 real discover-shard timings averaged 23.7 min/shard (billed 24). Before: 3 discover runs/day × 3 shards = 216 min/day. After: 1/day × 3 shards = 72 min/day. Saved 144 min/day × 30 ≈ 4,320 min/month. Roughly half the documented burn.
+
+## Open / next
+- **Merge PR #1263.** depup main ruleset blocks normal merges — needs `gh pr merge 1263 --admin --squash` (orchestrator/Mikl call). Deliberately not merged this session.
+- First live effect: the next daily-midnight cron is the first run where discover is skipped on the 08:00/16:00 ticks. Worth a glance at the next cron cycle to confirm sync still fires on all three ticks and discover only at 00:00.
+
+## Context that would be lost
+- Memory written: `project_actions_minutes_optimization.md` (project: depup) + MEMORY.md "Actions Minutes Optimization (2026-06-16)" section.
+- Key invariant for future cadence tuning: the "8h processing contract" = SYNC must stay every 8h; discovery/onboarding cadence is separable and can be relaxed.

--- a/scripts/__tests__/integration.test.js
+++ b/scripts/__tests__/integration.test.js
@@ -355,17 +355,17 @@ describe('cron-sync.mjs end-to-end', () => {
   );
 
   it(
-    'syncPackage detects up-to-date package',
+    'checkNeedsUpdate detects up-to-date package',
     async () => {
       const syncer = new PackageSyncer();
       const packages = await syncer.getExistingPackages();
       const isOdd = packages.find((p) => p.name === TEST_PACKAGE);
 
       // Recently processed -- should be skipped or up-to-date
-      const synced = await syncer.syncPackage(isOdd);
+      const check = await syncer.checkNeedsUpdate(isOdd);
 
-      // Returns false when package is up-to-date or recently processed
-      expect(synced).toBe(false);
+      // updateType is null when package is up-to-date or recently processed
+      expect(check.updateType).toBeNull();
     },
     TIMEOUT,
   );

--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -7488,10 +7488,10 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
-  // syncPackage (lines 157-203) -- spy on instance methods + fetch
+  // checkNeedsUpdate -- cheap pre-check (Phase 1), spy on instance methods + fetch
   // ─────────────────────────────────────────────────────────────────
-  describe('syncPackage', () => {
-    it('returns false when wasRecentlyProcessed is true (skip path)', async () => {
+  describe('checkNeedsUpdate', () => {
+    it('returns skip:true when wasRecentlyProcessed is true', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(true);
@@ -7503,10 +7503,13 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(false);
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(true);
+      expect(result.updateType).toBeNull();
     });
 
-    it('returns false when registry returns no latest version', async () => {
+    it('returns skip:true when registry returns no latest version', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(false);
@@ -7521,22 +7524,19 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(false);
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(true);
+      expect(result.updateType).toBeNull();
     });
 
-    it('calls updatePackage and generateReadme when version differs', async () => {
+    it('returns updateType:version when upstream version differs', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(false);
       jestInstance
         .spyOn(fetchModule.default, 'json')
         .mockResolvedValueOnce({ 'dist-tags': { latest: '5.0.0' } });
-      const updateSpy = jestInstance
-        .spyOn(syncer, 'updatePackage')
-        .mockResolvedValueOnce();
-      const readmeSpy = jestInstance
-        .spyOn(syncer, 'generateReadme')
-        .mockResolvedValueOnce();
 
       const package_ = {
         integrityData: {},
@@ -7545,12 +7545,37 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(true);
-      expect(updateSpy).toHaveBeenCalledWith(package_, '5.0.0');
-      expect(readmeSpy).toHaveBeenCalledWith('express');
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(false);
+      expect(result.updateType).toBe('version');
+      expect(result.latestVersion).toBe('5.0.0');
     });
 
-    it('calls updateDependencies and generateReadme when only deps need update', async () => {
+    it('returns updateType:failed-revisions when current version has only failed revisions', async () => {
+      jestInstance
+        .spyOn(syncer, 'wasRecentlyProcessed')
+        .mockResolvedValueOnce(false);
+      jestInstance
+        .spyOn(fetchModule.default, 'json')
+        .mockResolvedValueOnce({ 'dist-tags': { latest: '4.18.2' } });
+      // All revisions have status:failed -> hasOnlyFailedRevisions returns true
+      const package_ = {
+        integrityData: {
+          '4.18.2': { 0: { status: 'failed' } },
+        },
+        name: 'express',
+        path: temporaryDirectory,
+        version: '4.18.2',
+      };
+
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(false);
+      expect(result.updateType).toBe('failed-revisions');
+    });
+
+    it('returns updateType:deps when only deps need updating', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(false);
@@ -7560,26 +7585,21 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
       jestInstance
         .spyOn(syncer, 'checkDependencyUpdates')
         .mockResolvedValueOnce(true);
-      const depSpy = jestInstance
-        .spyOn(syncer, 'updateDependencies')
-        .mockResolvedValueOnce();
-      const readmeSpy = jestInstance
-        .spyOn(syncer, 'generateReadme')
-        .mockResolvedValueOnce();
 
       const package_ = {
-        integrityData: {},
+        integrityData: { '4.18.2': { 0: { status: 'published' } } },
         name: 'express',
         path: temporaryDirectory,
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(true);
-      expect(depSpy).toHaveBeenCalledWith(package_);
-      expect(readmeSpy).toHaveBeenCalledWith('express');
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(false);
+      expect(result.updateType).toBe('deps');
     });
 
-    it('returns false when same version and no dep updates needed', async () => {
+    it('returns updateType:null when package is up to date', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(false);
@@ -7591,16 +7611,19 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         .mockResolvedValueOnce(false);
 
       const package_ = {
-        integrityData: {},
+        integrityData: { '4.18.2': { 0: { status: 'published' } } },
         name: 'express',
         path: temporaryDirectory,
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(false);
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(false);
+      expect(result.updateType).toBeNull();
     });
 
-    it('returns false (catches error) when registry fetch throws', async () => {
+    it('returns updateType:null when registry fetch throws (catch path)', async () => {
       jestInstance
         .spyOn(syncer, 'wasRecentlyProcessed')
         .mockResolvedValueOnce(false);
@@ -7615,7 +7638,210 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         version: '4.18.2',
       };
 
-      await expect(syncer.syncPackage(package_)).resolves.toBe(false);
+      const result = await syncer.checkNeedsUpdate(package_);
+
+      expect(result.skip).toBe(false);
+      expect(result.updateType).toBeNull();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // applyUpdate -- dispatches to updatePackage or updateDependencies
+  // ─────────────────────────────────────────────────────────────────
+  describe('applyUpdate', () => {
+    it('calls updatePackage for updateType:version', async () => {
+      const updateSpy = jestInstance
+        .spyOn(syncer, 'updatePackage')
+        .mockResolvedValueOnce();
+
+      const package_ = {
+        name: 'express',
+        path: temporaryDirectory,
+        version: '4.18.2',
+      };
+      const check = { latestVersion: '5.0.0', updateType: 'version' };
+
+      await syncer.applyUpdate(package_, check);
+
+      expect(updateSpy).toHaveBeenCalledWith(package_, '5.0.0');
+    });
+
+    it('calls updatePackage for updateType:failed-revisions', async () => {
+      const updateSpy = jestInstance
+        .spyOn(syncer, 'updatePackage')
+        .mockResolvedValueOnce();
+
+      const package_ = {
+        name: 'express',
+        path: temporaryDirectory,
+        version: '4.18.2',
+      };
+      const check = { latestVersion: '4.18.2', updateType: 'failed-revisions' };
+
+      await syncer.applyUpdate(package_, check);
+
+      expect(updateSpy).toHaveBeenCalledWith(package_, '4.18.2');
+    });
+
+    it('calls updateDependencies for updateType:deps', async () => {
+      const depSpy = jestInstance
+        .spyOn(syncer, 'updateDependencies')
+        .mockResolvedValueOnce();
+
+      const package_ = {
+        name: 'lodash',
+        path: temporaryDirectory,
+        version: '4.17.21',
+      };
+      const check = { latestVersion: '4.17.21', updateType: 'deps' };
+
+      await syncer.applyUpdate(package_, check);
+
+      expect(depSpy).toHaveBeenCalledWith(package_);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // checkBatches -- Phase 1 high-concurrency check loop
+  // ─────────────────────────────────────────────────────────────────
+  describe('checkBatches', () => {
+    it('returns empty needsUpdate when all packages are up to date', async () => {
+      jestInstance
+        .spyOn(syncer, 'checkNeedsUpdate')
+        .mockResolvedValue({ latestVersion: '1.0.0', skip: false, updateType: null });
+
+      const packages = [
+        { name: 'a', version: '1.0.0' },
+        { name: 'b', version: '1.0.0' },
+      ];
+      syncer.rateLimitDelay = 0;
+
+      const { needsUpdate, skippedCount } = await syncer.checkBatches(packages);
+
+      expect(needsUpdate).toHaveLength(0);
+      expect(skippedCount).toBe(0);
+    });
+
+    it('counts skipped packages correctly', async () => {
+      jestInstance
+        .spyOn(syncer, 'checkNeedsUpdate')
+        .mockResolvedValue({ latestVersion: '1.0.0', skip: true, updateType: null });
+
+      const packages = [{ name: 'a', version: '1.0.0' }];
+      syncer.rateLimitDelay = 0;
+
+      const { needsUpdate, skippedCount } = await syncer.checkBatches(packages);
+
+      expect(needsUpdate).toHaveLength(0);
+      expect(skippedCount).toBe(1);
+    });
+
+    it('collects packages that need updating', async () => {
+      jestInstance
+        .spyOn(syncer, 'checkNeedsUpdate')
+        .mockResolvedValue({ latestVersion: '2.0.0', skip: false, updateType: 'version' });
+
+      const package_ = { name: 'express', version: '1.0.0' };
+      syncer.rateLimitDelay = 0;
+
+      const { needsUpdate } = await syncer.checkBatches([package_]);
+
+      expect(needsUpdate).toHaveLength(1);
+      expect(needsUpdate[0].package_).toBe(package_);
+      expect(needsUpdate[0].check.updateType).toBe('version');
+    });
+
+    it('handles a rejected checkNeedsUpdate without crashing', async () => {
+      jestInstance
+        .spyOn(syncer, 'checkNeedsUpdate')
+        .mockRejectedValueOnce(new Error('check failed'));
+
+      const packages = [{ name: 'bad-pkg', version: '1.0.0' }];
+      syncer.rateLimitDelay = 0;
+
+      const { needsUpdate } = await syncer.checkBatches(packages);
+
+      // Rejected checks don't add to needsUpdate -- they're just warned about
+      expect(needsUpdate).toHaveLength(0);
+    });
+
+    it('processes multiple batches when packages exceed checkConcurrentPackages', async () => {
+      jestInstance
+        .spyOn(syncer, 'checkNeedsUpdate')
+        .mockResolvedValue({ latestVersion: '1.0.0', skip: false, updateType: null });
+      syncer.checkConcurrentPackages = 2;
+      syncer.rateLimitDelay = 0;
+
+      const packages = Array.from({ length: 5 }, (_, i) => ({
+        name: `pkg-${i}`,
+        version: '1.0.0',
+      }));
+
+      const { needsUpdate } = await syncer.checkBatches(packages);
+
+      expect(needsUpdate).toHaveLength(0);
+      expect(syncer.checkNeedsUpdate).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // applyBatches -- Phase 2 low-concurrency update loop
+  // ─────────────────────────────────────────────────────────────────
+  describe('applyBatches', () => {
+    it('returns empty syncedPackages when needsUpdate list is empty', async () => {
+      const { failedCount, syncedPackages } = await syncer.applyBatches([]);
+
+      expect(syncedPackages).toHaveLength(0);
+      expect(failedCount).toBe(0);
+    });
+
+    it('records synced package name on success', async () => {
+      jestInstance.spyOn(syncer, 'applyUpdate').mockResolvedValueOnce();
+      jestInstance.spyOn(syncer, 'generateReadme').mockResolvedValueOnce();
+
+      const package_ = { name: 'express', version: '4.18.2' };
+      const check = { latestVersion: '5.0.0', updateType: 'version' };
+      syncer.rateLimitDelay = 0;
+
+      const { syncedPackages } = await syncer.applyBatches([
+        { check, package_ },
+      ]);
+
+      expect(syncedPackages).toEqual(['express']);
+    });
+
+    it('increments failedCount when applyUpdate throws', async () => {
+      jestInstance
+        .spyOn(syncer, 'applyUpdate')
+        .mockRejectedValueOnce(new Error('update failed'));
+      jestInstance.spyOn(syncer, 'generateReadme').mockResolvedValueOnce();
+
+      const package_ = { name: 'broken-pkg', version: '1.0.0' };
+      const check = { latestVersion: '2.0.0', updateType: 'version' };
+      syncer.rateLimitDelay = 0;
+
+      const { failedCount, syncedPackages } = await syncer.applyBatches([
+        { check, package_ },
+      ]);
+
+      expect(syncedPackages).toHaveLength(0);
+      expect(failedCount).toBe(1);
+    });
+
+    it('handles a rejected Promise.allSettled result (status rejected)', async () => {
+      // Simulate a case where the async wrapper itself rejects (rare but possible)
+      jestInstance
+        .spyOn(syncer, 'applyUpdate')
+        .mockRejectedValueOnce(new Error('hard crash'));
+      jestInstance.spyOn(syncer, 'generateReadme').mockResolvedValueOnce();
+
+      const package_ = { name: 'crash-pkg', version: '1.0.0' };
+      const check = { latestVersion: '1.0.0', updateType: 'failed-revisions' };
+      syncer.rateLimitDelay = 0;
+
+      const { failedCount } = await syncer.applyBatches([{ check, package_ }]);
+
+      expect(failedCount).toBe(1);
     });
   });
 
@@ -7805,13 +8031,19 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
-  // main (lines 16-89) -- spy on syncPackage + getExistingPackages
+  // main -- spy on checkBatches + applyBatches + getExistingPackages
   // ─────────────────────────────────────────────────────────────────
   describe('main', () => {
     it('logs starting message and calls getExistingPackages', async () => {
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
         .mockResolvedValueOnce([]);
+      jestInstance
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({ needsUpdate: [], skippedCount: 0 });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 0, syncedPackages: [] });
 
       await syncer.main();
 
@@ -7821,16 +8053,23 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
     });
 
     it('reports synced count when a package is successfully synced', async () => {
-      const mockPackage = {
-        integrityData: {},
-        name: 'express',
-        path: temporaryDirectory,
-        version: '4.18.2',
-      };
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce([mockPackage]);
-      jestInstance.spyOn(syncer, 'syncPackage').mockResolvedValueOnce(true);
+        .mockResolvedValueOnce([{ name: 'express', version: '4.18.2' }]);
+      jestInstance
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({
+          needsUpdate: [
+            {
+              check: { latestVersion: '5.0.0', updateType: 'version' },
+              package_: { name: 'express', version: '4.18.2' },
+            },
+          ],
+          skippedCount: 0,
+        });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 0, syncedPackages: ['express'] });
 
       await syncer.main();
 
@@ -7840,41 +8079,27 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
     });
 
     it('logs synced package names when at least one is synced', async () => {
-      const mockPackage = {
-        integrityData: {},
-        name: 'lodash',
-        path: temporaryDirectory,
-        version: '4.17.21',
-      };
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce([mockPackage]);
-      jestInstance.spyOn(syncer, 'syncPackage').mockResolvedValueOnce(true);
+        .mockResolvedValueOnce([{ name: 'lodash', version: '4.17.21' }]);
+      jestInstance
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({
+          needsUpdate: [
+            {
+              check: { latestVersion: '5.0.0', updateType: 'version' },
+              package_: { name: 'lodash', version: '4.17.21' },
+            },
+          ],
+          skippedCount: 0,
+        });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 0, syncedPackages: ['lodash'] });
 
       await syncer.main();
 
       expect(console.log).toHaveBeenCalledWith('Synced packages:', 'lodash');
-    });
-
-    it('handles rejected batch result (syncPackage throws) without crashing', async () => {
-      const mockPackage = {
-        integrityData: {},
-        name: 'bad-pkg',
-        path: temporaryDirectory,
-        version: '1.0.0',
-      };
-      jestInstance
-        .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce([mockPackage]);
-      jestInstance
-        .spyOn(syncer, 'syncPackage')
-        .mockRejectedValueOnce(new Error('sync crashed'));
-
-      await syncer.main();
-
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Synced 0 packages'),
-      );
     });
 
     it('exits with code 1 when getExistingPackages throws', async () => {
@@ -7890,18 +8115,21 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    it('processes multiple batches of packages (covers batching loop)', async () => {
-      const packages = Array.from({ length: 7 }, (_, index) => ({
-        integrityData: {},
-        name: `pkg-${index}`,
-        path: temporaryDirectory,
-        version: '1.0.0',
-      }));
+    it('reports zero synced packages when nothing needs updating', async () => {
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce(packages);
-      jestInstance.spyOn(syncer, 'syncPackage').mockResolvedValue(false);
-      syncer.rateLimitDelay = 0;
+        .mockResolvedValueOnce(
+          Array.from({ length: 7 }, (_, index) => ({
+            name: `pkg-${index}`,
+            version: '1.0.0',
+          })),
+        );
+      jestInstance
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({ needsUpdate: [], skippedCount: 0 });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 0, syncedPackages: [] });
 
       await syncer.main();
 
@@ -7910,34 +8138,16 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
       );
     });
 
-    it('warns about failed sync inside the batch (inner catch path)', async () => {
-      const mockPackage = {
-        integrityData: {},
-        name: 'warn-pkg',
-        path: temporaryDirectory,
-        version: '1.0.0',
-      };
-      jestInstance
-        .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce([mockPackage]);
-      // syncPackage throwing is caught by the inner try/catch in main(),
-      // which calls console.warn with "Failed to sync <name>:"
-      jestInstance
-        .spyOn(syncer, 'syncPackage')
-        .mockRejectedValueOnce(new Error('inner sync error'));
-
-      await syncer.main();
-
-      expect(console.warn).toHaveBeenCalledWith(
-        'Failed to sync warn-pkg:',
-        'inner sync error',
-      );
-    });
-
     it('emits DEPUP_SUMMARY line at end of successful run', async () => {
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
         .mockResolvedValueOnce([]);
+      jestInstance
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({ needsUpdate: [], skippedCount: 0 });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 0, syncedPackages: [] });
 
       await syncer.main();
 
@@ -7949,23 +8159,30 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
     });
 
     it('exits with 1 and logs SYSTEMIC FAILURE when >50% of 10+ attempts fail', async () => {
-      // Build 12 packages that will all fail
-      const packages = Array.from({ length: 12 }, (_, index) => ({
-        integrityData: {},
-        name: `fail-pkg-${index}`,
-        path: temporaryDirectory,
-        version: '1.0.0',
-      }));
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce(packages);
+        .mockResolvedValueOnce(
+          Array.from({ length: 12 }, (_, index) => ({
+            name: `fail-pkg-${index}`,
+            version: '1.0.0',
+          })),
+        );
+      // checkBatches returns 12 packages needing update, applyBatches fails all
       jestInstance
-        .spyOn(syncer, 'syncPackage')
-        .mockRejectedValue(new Error('boom'));
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({
+          needsUpdate: Array.from({ length: 12 }, (_, index) => ({
+            check: { latestVersion: '2.0.0', updateType: 'version' },
+            package_: { name: `fail-pkg-${index}`, version: '1.0.0' },
+          })),
+          skippedCount: 0,
+        });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 12, syncedPackages: [] });
       const exitSpy = jestInstance
         .spyOn(process, 'exit')
         .mockImplementation(() => {});
-      syncer.rateLimitDelay = 0;
 
       await syncer.main();
 
@@ -7976,22 +8193,29 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
     });
 
     it('does NOT trigger systemic failure when fewer than 10 packages attempted', async () => {
-      const packages = Array.from({ length: 3 }, (_, index) => ({
-        integrityData: {},
-        name: `small-fail-${index}`,
-        path: temporaryDirectory,
-        version: '1.0.0',
-      }));
       jestInstance
         .spyOn(syncer, 'getExistingPackages')
-        .mockResolvedValueOnce(packages);
+        .mockResolvedValueOnce(
+          Array.from({ length: 3 }, (_, index) => ({
+            name: `small-fail-${index}`,
+            version: '1.0.0',
+          })),
+        );
       jestInstance
-        .spyOn(syncer, 'syncPackage')
-        .mockRejectedValue(new Error('small fail'));
+        .spyOn(syncer, 'checkBatches')
+        .mockResolvedValueOnce({
+          needsUpdate: Array.from({ length: 3 }, (_, index) => ({
+            check: { latestVersion: '2.0.0', updateType: 'version' },
+            package_: { name: `small-fail-${index}`, version: '1.0.0' },
+          })),
+          skippedCount: 0,
+        });
+      jestInstance
+        .spyOn(syncer, 'applyBatches')
+        .mockResolvedValueOnce({ failedCount: 3, syncedPackages: [] });
       const exitSpy = jestInstance
         .spyOn(process, 'exit')
         .mockImplementation(() => {});
-      syncer.rateLimitDelay = 0;
 
       await syncer.main();
 
@@ -8067,8 +8291,8 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
   // ─────────────────────────────────────────────────────────────────
   // syncPackage -- retry when only failed revisions (FIX 2)
   // ─────────────────────────────────────────────────────────────────
-  describe('syncPackage -- retry on all-failed revisions', () => {
-    it('retries when version matches but all revisions are failed', async () => {
+  describe('checkNeedsUpdate -- retry on all-failed revisions', () => {
+    it('returns updateType:failed-revisions when version matches but all revisions are failed', async () => {
       const integrityData = {
         '1.0.0': { 'rev-1': { status: 'failed' } },
       };
@@ -8084,18 +8308,15 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
       jestInstance.spyOn(fetchModule.default, 'json').mockResolvedValueOnce({
         'dist-tags': { latest: '1.0.0' },
       });
-      const updateSpy = jestInstance
-        .spyOn(syncer, 'updatePackage')
-        .mockResolvedValueOnce();
-      jestInstance.spyOn(syncer, 'generateReadme').mockResolvedValueOnce();
 
-      const result = await syncer.syncPackage(package_);
+      const result = await syncer.checkNeedsUpdate(package_);
 
-      expect(updateSpy).toHaveBeenCalledWith(package_, '1.0.0');
-      expect(result).toBe(true);
+      expect(result.updateType).toBe('failed-revisions');
+      expect(result.skip).toBe(false);
+      expect(result.latestVersion).toBe('1.0.0');
     });
 
-    it('does NOT retry when version matches and at least one revision is published', async () => {
+    it('returns updateType:null when version matches and at least one revision is published', async () => {
       const integrityData = {
         '1.0.0': { 'rev-1': { status: 'published' } },
       };
@@ -8115,9 +8336,10 @@ describe('cron-sync.mjs -- coverage gap fill', () => {
         .spyOn(syncer, 'checkDependencyUpdates')
         .mockResolvedValueOnce(false);
 
-      const result = await syncer.syncPackage(package_);
+      const result = await syncer.checkNeedsUpdate(package_);
 
-      expect(result).toBe(false);
+      expect(result.updateType).toBeNull();
+      expect(result.skip).toBe(false);
     });
   });
 });

--- a/scripts/cron-sync.mjs
+++ b/scripts/cron-sync.mjs
@@ -13,43 +13,104 @@ import {
 } from './utilities.mjs';
 
 class PackageSyncer {
-  async processBatches(packagesToProcess) {
-    const syncedPackages = [];
-    let failedCount = 0;
+  /**
+   * Phase 1: cheap pre-check at high concurrency.
+   *
+   * For each package, determine whether it needs any work without spawning
+   * child processes. Network calls (registry fetches) are the only I/O here --
+   * no npm install, no test runs. Returns the list of packages that actually
+   * need to be updated so Phase 2 can process only those at safe concurrency.
+   */
+  async checkBatches(packagesToProcess) {
+    const needsUpdate = [];
     let skippedCount = 0;
+    let checkedCount = 0;
 
     for (
       let index = 0;
       index < packagesToProcess.length;
-      index += this.concurrentPackages
+      index += this.checkConcurrentPackages
     ) {
       const batch = packagesToProcess.slice(
         index,
-        index + this.concurrentPackages,
-      );
-      console.log(
-        `Processing batch ${Math.floor(index / this.concurrentPackages) + 1} (${batch.length} packages)...`,
+        index + this.checkConcurrentPackages,
       );
 
       const batchResults = await Promise.allSettled(
         batch.map(async (package_) => {
+          const check = await this.checkNeedsUpdate(package_);
+          return { check, package_ };
+        }),
+      );
+
+      for (const result of batchResults) {
+        if (result.status === 'fulfilled') {
+          const { check, package_ } = result.value;
+          if (check.skip) {
+            skippedCount++;
+          } else if (check.updateType === null) {
+            // up-to-date
+            checkedCount++;
+          } else {
+            needsUpdate.push({ check, package_ });
+            checkedCount++;
+          }
+        } else {
+          // Check itself failed -- include in update list so Phase 2 retries
+          console.warn(
+            `Pre-check failed for package: ${result.reason?.message || 'Unknown error'}`,
+          );
+          checkedCount++;
+        }
+      }
+
+      if (index + this.checkConcurrentPackages < packagesToProcess.length) {
+        await sleep(this.rateLimitDelay);
+      }
+    }
+
+    console.log(
+      `Pre-check complete: ${needsUpdate.length} packages need updates, ${checkedCount - needsUpdate.length} up-to-date, ${skippedCount} skipped`,
+    );
+    return { needsUpdate, skippedCount };
+  }
+
+  /**
+   * Phase 2: apply updates at safe concurrency (5 concurrent max).
+   *
+   * Each package here runs depup.mjs which spawns npm install + tests.
+   * The low concurrency limit prevents OOM on the 7 GB CI runner.
+   */
+  async applyBatches(packagesToUpdate) {
+    const syncedPackages = [];
+    let failedCount = 0;
+
+    for (
+      let index = 0;
+      index < packagesToUpdate.length;
+      index += this.concurrentPackages
+    ) {
+      const batch = packagesToUpdate.slice(
+        index,
+        index + this.concurrentPackages,
+      );
+      console.log(
+        `Applying updates batch ${Math.floor(index / this.concurrentPackages) + 1} (${batch.length} packages)...`,
+      );
+
+      const batchResults = await Promise.allSettled(
+        batch.map(async ({ check, package_ }) => {
           try {
-            console.log(`Syncing ${package_.name}...`);
-            const synced = await this.syncPackage(package_);
-            return {
-              name: package_.name,
-              skipped: !synced,
-              success: true,
-              synced,
-            };
+            console.log(`Syncing ${package_.name} (${check.updateType})...`);
+            await this.applyUpdate(package_, check);
+            await this.generateReadme(package_.name);
+            return { name: package_.name, success: true };
           } catch (error) {
             console.warn(`Failed to sync ${package_.name}:`, error.message);
             return {
               error: error.message,
               name: package_.name,
-              skipped: false,
               success: false,
-              synced: false,
             };
           }
         }),
@@ -57,11 +118,9 @@ class PackageSyncer {
 
       for (const result of batchResults) {
         if (result.status === 'fulfilled') {
-          if (result.value.synced) {
+          if (result.value.success) {
             syncedPackages.push(result.value.name);
-          } else if (result.value.success && result.value.skipped) {
-            skippedCount++;
-          } else if (!result.value.success) {
+          } else {
             failedCount++;
           }
         } else if (result.status === 'rejected') {
@@ -72,16 +131,16 @@ class PackageSyncer {
         }
       }
 
-      if (index + this.concurrentPackages < packagesToProcess.length) {
+      if (index + this.concurrentPackages < packagesToUpdate.length) {
         await sleep(this.rateLimitDelay);
       }
     }
 
-    return { failedCount, skippedCount, syncedPackages };
+    return { failedCount, syncedPackages };
   }
 
   async main() {
-    console.log('🔄 Starting package sync...');
+    console.log('Starting package sync...');
 
     try {
       const existingPackages = await this.getExistingPackages();
@@ -91,10 +150,16 @@ class PackageSyncer {
         0,
         this.maxPackagesPerRun,
       );
-      const { failedCount, skippedCount, syncedPackages } =
-        await this.processBatches(packagesToProcess);
 
-      console.log(`✅ Synced ${syncedPackages.length} packages`);
+      // Phase 1: cheap pre-check at high concurrency (no child processes)
+      const { needsUpdate, skippedCount } =
+        await this.checkBatches(packagesToProcess);
+
+      // Phase 2: apply updates at safe concurrency (spawns depup.mjs per package)
+      const { failedCount, syncedPackages } =
+        await this.applyBatches(needsUpdate);
+
+      console.log(`Synced ${syncedPackages.length} packages`);
       if (syncedPackages.length > 0) {
         console.log('Synced packages:', syncedPackages.join(', '));
       }
@@ -110,7 +175,7 @@ class PackageSyncer {
         process.exit(1);
       }
 
-      // Machine-readable summary for GitHub step summary (FIX 6)
+      // Machine-readable summary for GitHub step summary
       console.log(
         `DEPUP_SUMMARY processed=${syncedPackages.length} failed=${failedCount} skipped=${skippedCount}`,
       );
@@ -186,12 +251,26 @@ class PackageSyncer {
     return sortedPackages;
   }
 
-  async syncPackage(package_) {
+  /**
+   * Cheap determination of whether a package needs any work.
+   *
+   * Makes only registry network calls -- no child processes, no npm install.
+   * Returns { skip, updateType, latestVersion } where updateType is one of:
+   *   'version'          -- upstream released a newer version
+   *   'failed-revisions' -- current version never successfully published
+   *   'deps'             -- a production dep has a minor/major update available
+   *   null               -- nothing to do (up-to-date)
+   */
+  async checkNeedsUpdate(package_) {
     try {
       // Skip recently processed packages (e.g., just handled by discover)
       if (await this.wasRecentlyProcessed(package_)) {
         console.log(`  ${package_.name} was recently processed, skipping`);
-        return false;
+        return {
+          latestVersion: package_.version,
+          skip: true,
+          updateType: null,
+        };
       }
 
       // Get latest version from npm
@@ -206,46 +285,68 @@ class PackageSyncer {
         console.warn(
           `  No latest version found for ${package_.name}, skipping`,
         );
-        return false;
+        return {
+          latestVersion: package_.version,
+          skip: true,
+          updateType: null,
+        };
       }
 
-      // Check if we need to update
+      // Check if upstream released a new version
       if (latestVersion !== package_.version) {
         console.log(
-          `  🔄 Version update: ${package_.version} -> ${latestVersion}`,
+          `  Version update: ${package_.version} -> ${latestVersion}`,
         );
-        await this.updatePackage(package_, latestVersion);
-        await this.generateReadme(package_.name);
-        return true;
+        return { latestVersion, skip: false, updateType: 'version' };
       }
 
-      // Even if version matches, check whether the current version only has
-      // failed revisions -- meaning the publish never actually landed.
-      // If so, re-process rather than treating it as up-to-date.
+      // Check whether the current version only has failed revisions -- meaning
+      // the publish never actually landed, so we must retry.
       if (
         this.hasOnlyFailedRevisions(package_.integrityData, package_.version)
       ) {
         console.log(
-          `  🔄 ${package_.name}@${package_.version} has only failed revisions — retrying`,
+          `  ${package_.name}@${package_.version} has only failed revisions -- retrying`,
         );
-        await this.updatePackage(package_, package_.version);
-        await this.generateReadme(package_.name);
-        return true;
+        return {
+          latestVersion: package_.version,
+          skip: false,
+          updateType: 'failed-revisions',
+        };
       }
 
-      // Check if dependencies need updating
+      // Check if production dependencies need updating
       const needsDependencyUpdate = await this.checkDependencyUpdates(package_);
       if (needsDependencyUpdate) {
-        console.log(`  🔄 Dependencies need updating`);
-        await this.updateDependencies(package_);
-        await this.generateReadme(package_.name);
-        return true;
+        console.log(`  ${package_.name} dependencies need updating`);
+        return {
+          latestVersion: package_.version,
+          skip: false,
+          updateType: 'deps',
+        };
       }
-      console.log(`  ✅ ${package_.name} is up to date`);
-      return false;
+
+      console.log(`  ${package_.name} is up to date`);
+      return { latestVersion: package_.version, skip: false, updateType: null };
     } catch (error) {
-      console.warn(`  ⚠️  Could not sync ${package_.name}:`, error.message);
-      return false;
+      console.warn(`  Could not check ${package_.name}:`, error.message);
+      return { latestVersion: package_.version, skip: false, updateType: null };
+    }
+  }
+
+  /**
+   * Apply the update determined by checkNeedsUpdate.
+   *
+   * Spawns depup.mjs as a child process (expensive: npm install + tests + publish).
+   */
+  async applyUpdate(package_, check) {
+    if (
+      check.updateType === 'version' ||
+      check.updateType === 'failed-revisions'
+    ) {
+      await this.updatePackage(package_, check.latestVersion);
+    } else if (check.updateType === 'deps') {
+      await this.updateDependencies(package_);
     }
   }
 
@@ -398,11 +499,11 @@ class PackageSyncer {
       });
 
       console.log(
-        `  ✅ Successfully updated ${package_.name} to ${updatedVersion}`,
+        `  Successfully updated ${package_.name} to ${updatedVersion}`,
       );
     } catch (error) {
       console.error(
-        `  ❌ Failed to update ${package_.name} to ${updatedVersion}:`,
+        `  Failed to update ${package_.name} to ${updatedVersion}:`,
         error.message,
       );
       throw error;
@@ -427,12 +528,10 @@ class PackageSyncer {
         timeout: 300_000,
       });
 
-      console.log(
-        `  ✅ Successfully updated dependencies for ${package_.name}`,
-      );
+      console.log(`  Successfully updated dependencies for ${package_.name}`);
     } catch (error) {
       console.error(
-        `  ❌ Failed to update dependencies for ${package_.name}:`,
+        `  Failed to update dependencies for ${package_.name}:`,
         error.message,
       );
       throw error;
@@ -566,12 +665,16 @@ class PackageSyncer {
     }
   }
 
-  registry = 'https://registry.npmjs.org';
-  rateLimitDelay = 100;
-  maxPackagesPerRun = 600;
-  // Limit to 5 concurrent packages (heavy operations spawn depup.mjs child
-  // processes that each run npm install -- 20 concurrent would OOM the runner)
+  // High concurrency for Phase 1 (cheap checks: registry fetches only, no
+  // child processes). 20 concurrent is safe because each request is just an
+  // HTTP call with no meaningful memory overhead on the CI runner.
+  checkConcurrentPackages = 20;
+  // Low concurrency for Phase 2 (expensive: spawns depup.mjs per package which
+  // runs npm install + tests). 5 concurrent prevents OOM on the 7 GB runner.
   concurrentPackages = 5;
+  maxPackagesPerRun = 600;
+  rateLimitDelay = 100;
+  registry = 'https://registry.npmjs.org';
 }
 
 export { PackageSyncer };

--- a/scripts/cron-sync.mjs
+++ b/scripts/cron-sync.mjs
@@ -56,7 +56,9 @@ class PackageSyncer {
             checkedCount++;
           }
         } else {
-          // Check itself failed -- include in update list so Phase 2 retries
+          // Check itself failed unexpectedly (checkNeedsUpdate catches its own
+          // errors, so this path is defensive). Treat as up-to-date this run;
+          // the next cron cycle will re-check.
           console.warn(
             `Pre-check failed for package: ${result.reason?.message || 'Unknown error'}`,
           );


### PR DESCRIPTION
## Summary

- **Two-phase sync pre-check (Change A):** `cron-sync.mjs` now runs a cheap Phase 1 (`checkBatches`) at high concurrency (20 parallel) that makes only registry HTTP calls — no child processes, no npm install. Only packages that actually need an update proceed to Phase 2 (`applyBatches`), which spawns `depup.mjs` at the same safe concurrency of 5. Packages that are already up-to-date never enter the expensive path.
- **Daily discover cadence (Change B):** `cron.yml` now runs two schedules: `0 8,16 * * *` (sync + heal only) and `0 0 * * *` (full pipeline including discover). Discover drops from 3x/day to 1x/day. Sync still runs at 00:00, 08:00, and 16:00 UTC — the 8h processing contract is unchanged.

## Why it's safe

- **Sync contract unchanged.** Sync still runs every 8h (00:00, 08:00, 16:00 UTC). The `sync` job's `if:` already includes `needs.discover.result == 'skipped'`, so it runs correctly on the `0 8,16` ticks where discover is skipped. Verified by reading the workflow — no change needed to the sync or heal `if:` conditions.
- **Discover daily loses nothing.** New packages only enter via: (1) the weekly curated-list refresh (`refresh-list.yml`, runs separately), or (2) user issue submissions that publish immediately through `process-package-request.yml` and bypass discover entirely. Running discover 3x/day added zero value.
- **72 cron-sync tests pass** covering `checkBatches`, `applyBatches`, `checkNeedsUpdate`, `applyUpdate`, and `main` — including Phase 1 pre-check logic, rejection handling, batch sizing, and the systemic-failure detection gate.

## Projected savings (measured)

Measured discover shard wall-clock from 2 recent successful runs (6 shards total):

| Run | Shard 0 | Shard 1 | Shard 2 |
|-----|---------|---------|---------|
| 27609287868 | 1280s | 1492s | 1400s |
| 27587233651 | 1410s | 1421s | 1527s |

Average: 1422s = 23.7 min/shard → billed as 24 min/shard (GitHub rounds up per job)

```
Before: 3 discover-runs/day × 3 shards × 24 min = 216 min/day
After:  1 discover-run/day  × 3 shards × 24 min =  72 min/day
Saved:  144 min/day = 4,320 min/month (~72 hours/month)
```

## Test Plan

- Jest (cron-sync tests, 72 passing):
  ```
  Tests: 840 skipped, 72 passed, 912 total
  Time: 0.813s
  ```
- Full unit suite: 863 passed, 49 failed (all 49 are `refresh-curated-list` setTimeout failures — known Node 26 local artifact; CI/Node 24 is green)
- YAML validation: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/cron.yml')); print('YAML OK')"` → `YAML OK`
- actionlint: 8 pre-existing SC2086 shellcheck info notices in git rebase loops (present on main before this PR, not introduced here)