### PR TITLE
fix: extract sleep seam in CuratedListRefresher to fix Node 26 timer spy

### DIFF
--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -11519,13 +11519,10 @@ describe('refresh-curated-list.mjs -- coverage gap fill', () => {
     jestInstance.spyOn(console, 'warn').mockImplementation(() => {});
     jestInstance.spyOn(console, 'error').mockImplementation(() => {});
 
-    // Speed up setTimeout (rate-limit delays)
-    jestInstance
-      .spyOn(globalThis, 'setTimeout')
-      .mockImplementation((function_) => {
-        function_();
-        return 0;
-      });
+    // Speed up sleep calls (rate-limit delays) -- spy on the instance method
+    // instead of globalThis.setTimeout, which is not spyable inside the Jest
+    // VM module sandbox on Node 26+.
+    jestInstance.spyOn(refresher, 'sleep').mockResolvedValue(undefined);
   });
 
   afterEach(async () => {

--- a/scripts/refresh-curated-list.mjs
+++ b/scripts/refresh-curated-list.mjs
@@ -149,15 +149,11 @@ class CuratedListRefresher {
         this.collectResults(results, seen, packages);
 
         // Rate limit courtesy -- npm returns 429 without delay
-        await new Promise((resolve) => {
-          setTimeout(resolve, 500);
-        });
+        await this.sleep(500);
       } catch (error) {
         if (error.statusCode === 429) {
           spinner.text = `Rate limited on "${query}", waiting 5s...`;
-          await new Promise((resolve) => {
-            setTimeout(resolve, 5000);
-          });
+          await this.sleep(5000);
         } else {
           console.warn(
             chalk.yellow(
@@ -212,6 +208,12 @@ class CuratedListRefresher {
       timeout: 10_000,
     });
     return result.objects || [];
+  }
+
+  sleep(ms) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
   }
 
   shouldSkip(name) {


### PR DESCRIPTION
## Summary

- `jest.spyOn(globalThis, 'setTimeout')` fails in the Jest `--experimental-vm-modules` sandbox on Node 26 with `Property \`setTimeout\` does not exist in the provided object`, causing 49 test failures locally while CI on Node 24 stays green
- Extracted the two `setTimeout` calls in `CuratedListRefresher.main()` into a `sleep(ms)` instance method — the established depup seam pattern from the security modules
- Tests now spy on `refresher.sleep` instead of `globalThis.setTimeout`; version-agnostic, works on Node 24 and Node 26

## Root cause

In the Jest `--experimental-vm-modules` sandbox on Node 26, `globalThis` is a realm proxy that does not expose `setTimeout` as a spyable own property. `jest-mock`'s `spyOn` checks `object[methodKey]` and throws when falsy.

## Test plan

- [ ] `npm test` passes with 982 tests, 0 failures on this Node 26.3.0 machine
- [ ] `npm run lint` passes with 0 errors
- [ ] CI on Node 24 (existing green bar) continues to pass