### PR TITLE
ci: add Node 26 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,13 @@ concurrency:
 
 jobs:
   test:
-    name: Unit Tests
+    name: Unit Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['24', '26']
 
     steps:
       - name: Checkout
@@ -44,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

- Adds Node 26 to the \`test.yml\` unit test matrix alongside Node 24
- Prevents a recurrence of the silent Node 26 VM sandbox bug fixed in PR #1264 (where \`setTimeout\` was no longer a spyable own property under \`--experimental-vm-modules\` in Node 26)
- Uses \`fail-fast: false\` so both legs always run and report independently
- No changes to scripts, tests, or actions — only the matrix strategy on the single job that runs \`npm run test:unit\`
- \`--experimental-vm-modules\` is preserved on both legs (it lives in the npm script itself, not in the workflow)
- All action refs remain SHA-pinned and permissions remain \`contents: read\` (read-only, unchanged)

## Test Plan

- [ ] CI runs two parallel jobs: \`Unit Tests (Node 24)\` and \`Unit Tests (Node 26)\`
- [ ] Both legs pass (or, if Node 26 reveals a new failure, the red leg is the signal we want)
- [ ] No regression on Node 24 leg