### PR TITLE
chore: pin transitive js-yaml to 4.2.0 to clear 17 moderate audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "stylelint": "16.26.1"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=24.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -913,13 +913,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -980,29 +973,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -4288,14 +4258,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -5029,36 +4996,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -6272,20 +6209,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -8616,14 +8539,23 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -11589,13 +11521,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
   "author": "Mikl Wolfe <wolfe@mikl.io> (https://github.com/chiefmikey)",
   "prettier": "mikey-pro/prettier",
   "overrides": {
-    "@boundaries/elements": "2.0.1"
+    "@boundaries/elements": "2.0.1",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^4.2.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- All 17 moderate advisories (GHSA-h67p-54hq-rp68) collapse to a single root cause: `js-yaml@3.14.2` reachable only via the istanbul coverage chain (`jest → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml`).
- Fixed with a scoped npm `overrides` entry pinning `@istanbuljs/load-nyc-config`'s `js-yaml` to `^4.2.0` — minimum blast radius, no declared-dep changes.
- `npm audit fix` (non-force) was a confirmed no-op; this PR uses the override mechanism as the correct non-breaking remediation.

## Advisory Summary

| Advisory | Severity | Root dep | Status | Notes |
|---|---|---|---|---|
| GHSA-h67p-54hq-rp68 (js-yaml quadratic DoS, merge-key aliases) | Moderate (×17) | `js-yaml <=4.1.1` via `@istanbuljs/load-nyc-config@1.1.0` | RESOLVED | Override pins to patched `4.2.0` |

The other two `js-yaml` copies in the tree (via eslint and stylelint) were already on `4.2.0` and were left untouched.

## Why not `npm audit fix`?

`npm audit fix --dry-run` changes 0 packages — the only npm-proposed fix is `npm audit fix --force`, which would downgrade jest from `30.4.2` to `25.0.0` (a semver-major breaking change). That was deliberately not taken.

The correct non-breaking remediation is an `overrides` entry that forces the specific transitive consumer (`@istanbuljs/load-nyc-config`) to resolve `js-yaml` to the patched version.

## Change

```json
"overrides": {
  "@boundaries/elements": "2.0.1",
  "@istanbuljs/load-nyc-config": {
    "js-yaml": "^4.2.0"
  }
}
```

## Test Plan

**Before (17 moderate vulnerabilities):**
```
js-yaml <=4.1.1 — GHSA-h67p-54hq-rp68 (×17 paths through jest toolchain)
npm audit: 17 moderate severity vulnerabilities
```

**After `npm install` (override applied):**
```
npm ls js-yaml --all:
  jest → @jest/core → @jest/transform → babel-plugin-istanbul
    → @istanbuljs/load-nyc-config → js-yaml@4.2.0 deduped  ← was 3.14.2
  mikey-pro → ... → eslint → @eslint/eslintrc → js-yaml@4.2.0 deduped
  stylelint → cosmiconfig → js-yaml@4.2.0
```

**npm test (unit tests — single-file path to exclude worktree stray copies):**
```
Test Suites: 1 passed, 1 total
Tests:       912 passed, 912 total
Snapshots:   0 total
Time:        14.128 s
```

**npm run test:coverage (exercises babel-plugin-istanbul → load-nyc-config → js-yaml — critical safeLoad path):**
```
Test Suites: 1 passed, 1 total
Tests:       912 passed, 912 total
Snapshots:   0 total
Time:        13.776 s
```
No `safeLoad` runtime error. Coverage collection completed successfully.
(Pre-existing coverage threshold warnings for `add-package.mjs` and `cli.mjs` are unrelated to this change.)

**npm ci (strict lockfile consistency check — mirrors CI behavior):**
```
found 0 vulnerabilities
```

**npm audit (post-fix):**
```
found 0 vulnerabilities
```

Before: 17 moderate | After: 0