### PR TITLE
feat: add npm ecosystem to Dependabot so devDeps auto-bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Dependabot was already active and working for the `github-actions` ecosystem — confirmed via PR #1268 merged 2026-06-21 and 30 total Dependabot PRs historically
- The gap was that `npm` was never added to the Dependabot config, which is why devDep bumps like #1266 (js-yaml) and #1267 (eslint/pacote/prettier/semver) had to be done manually
- This PR adds an `npm` ecosystem block matching the existing `github-actions` style: weekly schedule, `chore` commit prefix, all packages grouped into a single `npm` group PR to avoid PR spam

## Test Plan

- [x] YAML validated: `python3 -c "import yaml,sys; yaml.safe_load(open(".github/dependabot.yml")); print("YAML OK")"` -> `YAML OK`
- [ ] Dependabot will pick up the new ecosystem on its next scheduled run and begin opening grouped PRs for npm devDep updates
- [ ] No existing pin behavior is disrupted — Dependabot respects exact-pinned versions in package.json and simply opens a PR; merging is still a manual decision