### PR TITLE
test: add unit coverage for cli.mjs decision logic

### DIFF
--- a/scripts/__tests__/cli.test.js
+++ b/scripts/__tests__/cli.test.js
@@ -3,7 +3,14 @@
  * jest.unstable_mockModule('node:child_process') that must not leak into other
  * blocks. Jest gives each test file its own module registry, so this is hermetic.
  */
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 
 // jest.unstable_mockModule must be evaluated before any dynamic import('../cli.mjs').
 // Placing it here (module evaluation time) ensures the mock is registered first.
@@ -717,6 +724,181 @@ describe('cli.mjs -- coverage gap fill', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
+  // _validateVersion -- extracted validator method
+  // ─────────────────────────────────────────────────────────────────
+  describe('_validateVersion', () => {
+    it('accepts a non-empty version string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateVersion('1.0.0')).toBe(true);
+    });
+
+    it('accepts a version with whitespace content', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateVersion(' 2.0 ')).toBe(true);
+    });
+
+    it('rejects undefined', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateVersion()).toBe('Version is required');
+    });
+
+    it('rejects empty string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateVersion('')).toBe('Version is required');
+    });
+
+    it('rejects whitespace-only string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateVersion('   ')).toBe('Version is required');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // _validateRevision -- extracted validator method
+  // ─────────────────────────────────────────────────────────────────
+  describe('_validateRevision', () => {
+    it('accepts a zero revision', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('0')).toBe(true);
+    });
+
+    it('accepts a multi-digit numeric revision', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('42')).toBe(true);
+    });
+
+    it('rejects a non-numeric string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('abc')).toBe('Revision must be a number');
+    });
+
+    it('rejects a float string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('1.5')).toBe('Revision must be a number');
+    });
+
+    it('rejects empty string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('')).toBe('Revision must be a number');
+    });
+
+    it('rejects alphanumeric', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validateRevision('1a')).toBe('Revision must be a number');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // _validatePackageName -- extracted validator method
+  // ─────────────────────────────────────────────────────────────────
+  describe('_validatePackageName', () => {
+    it('accepts a valid unscoped package name', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('express')).toBe(true);
+    });
+
+    it('accepts a scoped package name', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('@nestjs/common')).toBe(true);
+    });
+
+    it('rejects empty string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('')).toBe('Package name is required');
+    });
+
+    it('rejects whitespace-only string', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('   ')).toBe('Package name is required');
+    });
+
+    it('rejects undefined', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName()).toBe('Package name is required');
+    });
+
+    it('rejects semicolons', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('pkg;rm')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects backticks', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('pkg`cmd`')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects dollar signs', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('$evil')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects pipe characters', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('pkg|other')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects angle brackets', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('a>b')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects less-than sign', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('a<b')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects curly braces', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('{bad}')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+
+    it('rejects square brackets', () => {
+      const cli = new DepUpCLI();
+
+      expect(cli._validatePackageName('[bad]')).toBe(
+        'Package name contains invalid characters',
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // run()
   // ─────────────────────────────────────────────────────────────────
   describe('run', () => {
@@ -733,4 +915,3 @@ describe('cli.mjs -- coverage gap fill', () => {
     });
   });
 });
-

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -165,6 +165,24 @@ class DepUpCLI {
     }
   }
 
+  _validateVersion(input) {
+    return input && input.trim() ? true : 'Version is required';
+  }
+
+  _validateRevision(input) {
+    return /^\d+$/u.test(input) ? true : 'Revision must be a number';
+  }
+
+  _validatePackageName(input) {
+    if (!input || !input.trim()) {
+      return 'Package name is required';
+    }
+    if (/[;`$|><\\{}[\]!#%^&*()='"]/u.test(input)) {
+      return 'Package name contains invalid characters';
+    }
+    return true;
+  }
+
   async handleIntegrityCommand(options) {
     try {
       if (options.vote) {
@@ -173,15 +191,13 @@ class DepUpCLI {
             message: 'Version:',
             name: 'version',
             type: 'input',
-            validate: (input) =>
-              input && input.trim() ? true : 'Version is required',
+            validate: (input) => this._validateVersion(input),
           },
           {
             message: 'Revision number:',
             name: 'revision',
             type: 'input',
-            validate: (input) =>
-              /^\d+$/u.test(input) ? true : 'Revision must be a number',
+            validate: (input) => this._validateRevision(input),
           },
           {
             choices: [
@@ -309,15 +325,7 @@ class DepUpCLI {
             message: 'Package name:',
             name: 'name',
             type: 'input',
-            validate: (input) => {
-              if (!input || !input.trim()) {
-                return 'Package name is required';
-              }
-              if (/[;`$|><\\{}[\]!#%^&*()='"]/u.test(input)) {
-                return 'Package name contains invalid characters';
-              }
-              return true;
-            },
+            validate: (input) => this._validatePackageName(input),
           },
           {
             message: 'Version (optional):',


### PR DESCRIPTION
## Summary

This PR is a **function-coverage and maintainability improvement**, not the closing of a line/branch gap. `cli.mjs` was already >=80% line and branch covered before this change (via the pre-existing `cli.test.js`).

The three `inquirer` `validate` functions inside `handleIntegrityCommand` and `handleInteractiveAction` were previously defined as inline lambdas, reachable only through interactive prompts — so they had no direct function-level test coverage. This PR:

- Extracts the three inline validators into named methods (`_validateVersion`, `_validateRevision`, `_validatePackageName`) — a minimal, behavior-preserving refactor. The lambda call sites now delegate to these methods; runtime behavior is identical.
- Adds 24 direct unit tests for the extracted methods covering valid input, empty/whitespace/undefined rejection, and each shell-unsafe character class.

## Coverage delta (measured with BOTH test files: unit.test.js + cli.test.js)

| Metric | main baseline (pre-existing cli.test.js) | this branch (+24 tests) | delta |
|--------|------------------------------------------|-------------------------|-------|
| cli.mjs statements | 88.8% | 89.06% | +0.26pp |
| cli.mjs branches | 97.72% | 97.72% | unchanged |
| cli.mjs functions | 68.42% | 72.72% | +4.3pp |
| cli.mjs lines | 88.8% | 89.06% | +0.26pp |

The earlier "0/0/0/0 before" figure was a measurement artifact: it came from running coverage on `unit.test.js` alone, which does not import `DepUpCLI` and therefore reports cli.mjs as 0% even though `cli.test.js` already covered it. The corrected baseline above runs both test files together.

The main value is the **+4.3pp function coverage** (the 3 validators are now directly tested as functions) plus the maintainability win of having named, independently testable validators instead of inline lambdas.

## Note on other modules

The 8 other target modules (depup.mjs, cron-discover.mjs, cron-sync.mjs, generate-readme.mjs, heal.mjs, integrity-meter.mjs, refresh-curated-list.mjs, utilities.mjs) were already at >=80% line+branch coverage. No changes were needed there.

## Test plan

- [x] All 64 tests in `scripts/__tests__/cli.test.js` pass (40 pre-existing + 24 new validator-method tests)
- [x] All 912 tests in `scripts/__tests__/unit.test.js` pass — no regression
- [x] Combined run (unit + cli): 976 tests pass
- [x] `npm run lint` on changed files: 0 errors (warnings only, consistent with existing test file patterns)
- [x] cli.mjs branch coverage: 97.72% (above 80% threshold, unchanged)
- [x] cli.mjs line coverage: 89.06% (above 80% threshold)