### PR TITLE
chore: trim performance monitoring workflow (monthly + drop redundant benchmark job)

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,7 +2,7 @@ name: Performance Monitoring
 
 on:
   schedule:
-    - cron: "0 6 * * 0"
+    - cron: "0 6 1 * *"  # monthly (1st, 06:00 UTC) — perf monitoring is a low-signal dry-run trend
   workflow_dispatch:
     inputs:
       package:
@@ -136,42 +136,3 @@ jobs:
             echo "- **Peak Memory Usage**: ${PEAK_RSS}MB" >> $GITHUB_STEP_SUMMARY
           fi
 
-  benchmark-comparison:
-    name: Benchmark Comparison
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    if: github.event_name == 'schedule'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run benchmark comparison
-        run: |
-          echo "Running benchmark comparison..."
-
-          # Test multiple packages for comparison
-          PACKAGES=("lodash" "express" "axios" "moment")
-
-          for package in "${PACKAGES[@]}"; do
-            echo "Benchmarking $package..."
-
-            start_time=$(date +%s)
-            npm run depup -- "$package" --debug --dry-run
-            end_time=$(date +%s)
-
-            processing_time=$((end_time - start_time))
-            echo "$package: ${processing_time}s"
-          done


### PR DESCRIPTION
## Summary
The performance-monitoring workflow was flagged in an old billing handoff as part of depup's ~9k min/month Actions burn. On inspection it is **not** a material cost: it runs weekly and recent runs finish in ~40s wall-clock (~10-180 min/month total). The 9k burn was the every-8h discover/sync job, already ~halved by moving discover to daily (live in main).

This PR trims the performance workflow on its own merits:
- **Removed the `benchmark-comparison` job** — persisted no artifact (logs only), 90-min timeout, redundant with `performance-test`.
- **Schedule weekly -> monthly** (`0 6 1 * *`).

Artifact contract unchanged: `performance-test` still produces `performance-metrics.json` + `memory-metrics.json`.

## Test Plan
- YAML parses (yaml.safe_load OK).
- Reproduced metric-construction logic locally: both JSON artifacts still generate as valid data with identical schema.
- Diff: 1 file changed, +1/-40.

Estimated new cost for this workflow: ~1-2 min/month (from ~10-180). Immaterial vs the 9k baseline — the meaningful reduction already happened in the package job.