### PR TITLE
chore: bump pinned Docker base images (node 20->24-alpine, clamav pinned to 1.5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DepUp Security Sandbox - Isolated Package Processing Environment
-FROM node:20-alpine
+FROM node:24-alpine
 
 # Install security tools and dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.security
+++ b/Dockerfile.security
@@ -1,5 +1,5 @@
 # DepUp Security Scanner - Pre-publication Security Validation
-FROM node:20-alpine
+FROM node:24-alpine
 
 # Install security scanning tools
 RUN apk add --no-cache \
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 
 # Install additional security tools via npm
 RUN npm install -g \
-    @snyk/cli \
+    snyk \
     audit-ci \
     npm-check-updates \
     && npm cache clean --force
@@ -24,6 +24,7 @@ RUN addgroup -g 1001 -S depup && \
     adduser -u 1001 -S depup -G depup
 
 WORKDIR /app
+RUN chown depup:depup /app
 
 # Create npm cache directory writable by depup user
 RUN mkdir -p /tmp/npm-cache && chown depup:depup /tmp/npm-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     # No command — Dockerfile ENTRYPOINT handles execution
 
   clamav-daemon:
-    image: clamav/clamav:latest
+    image: clamav/clamav:1.5
     container_name: depup-clamav
     networks:
       - depup-secure


### PR DESCRIPTION
## Summary
Bumps the 3 outdated pinned Docker base images flagged by infra monitoring.

- `Dockerfile` + `Dockerfile.security`: `node:20-alpine` -> `node:24-alpine`. `package.json` engines require `>=24.15.0` and CI already runs Node 24, so the old pin was a real mismatch.
- `docker-compose.yml`: `clamav/clamav:latest` -> `clamav/clamav:1.5`. Pins the floating tag to the current stable release line. `1.5`'s manifest digest is identical to today's `latest`, so no behavior change today, but it stops the tag floating and tracks security patches within the stable line.

### Note: two latent `Dockerfile.security` build fixes (Docker-config only, no source)
CI only builds `./Dockerfile` (`container-build` job); `Dockerfile.security` is only referenced by `docker-compose.yml` and was never built in CI, so it had silently rotted. Building it to verify the node bump surfaced two pre-existing bugs that would fail identically on node 20:
- `@snyk/cli` is not a real npm package (404) -> corrected to `snyk`.
- `/app` was never `chown`ed to the non-root `depup` user before `USER depup`, so `npm ci` hit `EACCES` -> added `RUN chown depup:depup /app` (mirrors the existing pattern in `Dockerfile`).

Both are Docker build-config lines. No application source (`*.mjs`) touched.

## Test Plan
- [x] `docker build -f Dockerfile .` -> SUCCESS; `node --version` -> `v24.18.0`
- [x] `docker build -f Dockerfile.security .` -> SUCCESS; `node v24.18.0`, `snyk 1.1306.0`, `ClamAV 1.4.5` all present in the built image
- [x] `docker manifest inspect clamav/clamav:1.5` resolves (current stable, digest-identical to `latest`)
- [x] Diff scope: 3 files, only image + 2 build-fix lines, zero application source
- [ ] CI: `depup-secure.yml` container-build (builds `./Dockerfile`) + `performance.yml` green on the new images
