### PR TITLE
fix: fail fast in cron when NPM_TOKEN is dead to stop wasting CI minutes

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,6 +49,15 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify npm auth (fail fast on dead NPM_TOKEN)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if ! npm whoami; then
+            echo "::error::NPM_TOKEN is invalid or expired (npm whoami failed). Rotate the npm automation token at npmjs.com and update the NPM_TOKEN repo secret. Aborting early to avoid wasting CI minutes."
+            exit 1
+          fi
+
       - name: Install Dependencies
         run: npm ci
 
@@ -181,6 +190,15 @@ jobs:
           node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm auth (fail fast on dead NPM_TOKEN)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if ! npm whoami; then
+            echo "::error::NPM_TOKEN is invalid or expired (npm whoami failed). Rotate the npm automation token at npmjs.com and update the NPM_TOKEN repo secret. Aborting early to avoid wasting CI minutes."
+            exit 1
+          fi
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- **Root cause (unchanged since 2026-01-13, last green cron run 2026-06-16):** the scheduled "Automated Discovery & Sync" workflow has failed every run since 2026-06-16 because the `NPM_TOKEN` repo secret is dead/expired. The `discover` and `sync` jobs run for 35-60 minutes, then the publish step fails with npm `404 do not have permission` / `429`, and the script's own detector logs `SYSTEMIC FAILURE ... Possible dead NPM_TOKEN`.
- **This PR does NOT fix that.** The actual fix is rotating the npm automation token and updating the `NPM_TOKEN` repository secret, which requires the repo owner's npm account access and is out of scope here — no secret is touched by this change.
- **What this PR does:** adds a `npm whoami` preflight step to the `discover` and `sync` jobs (immediately after "Setup Node.js", before "Install Dependencies"). If the token is dead, the job now fails in seconds with a clear `::error::` message instead of burning 35-60 minutes across 3 parallel shards, every 8 hours (~2.5 CI-hours/day wasted today). The `heal` job is untouched — it doesn't publish, so it doesn't need the check.

## Test Plan

- YAML validated: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/cron.yml')); print('YAML OK')"` -> `YAML OK`
- `actionlint .github/workflows/cron.yml` -> only pre-existing shellcheck `SC2086` info-level notices in unrelated, pre-existing retry-loop scripts (lines 159/294); no new findings from this change.
- This is a workflow-only YAML change — no path-scoped CI runs against it in this repo. The green signal here is `mergeStateStatus: CLEAN` / `mergeable: MERGEABLE` from `gh pr view`.