### PR TITLE
fix: prevent NPM_TOKEN exfiltration via untrusted install scripts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,12 +67,15 @@ export default [
   },
   {
     // Core pipeline has batch-processing orchestrator with validated early-exit guards
-    // and input validation adding necessary lines to processPackageCore
+    // and input validation adding necessary lines to processPackageCore. The
+    // install-method arrays were extracted into testable getters and the
+    // subprocess env is now sanitized to scrub NPM_TOKEN/NODE_AUTH_TOKEN
+    // before untrusted installs run -- both add a handful of necessary lines.
     files: ['scripts/depup.mjs'],
     rules: {
       complexity: ['error', { max: 15 }],
       'sonarjs/cognitive-complexity': ['warn', 15],
-      'max-lines': ['error', { max: 1195, skipBlankLines: true, skipComments: true }],
+      'max-lines': ['error', { max: 1210, skipBlankLines: true, skipComments: true }],
       'max-lines-per-function': [
         'error',
         { max: 85, skipBlankLines: true, skipComments: true },

--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -345,6 +345,95 @@ describe('depUp class', () => {
     });
   });
 
+  describe('buildSanitizedInstallEnvironment', () => {
+    it('strips both publish tokens while preserving other env vars', () => {
+      const originalNpmToken = process.env.NPM_TOKEN;
+      const originalNodeAuthToken = process.env.NODE_AUTH_TOKEN;
+      const originalPath = process.env.PATH;
+      process.env.NPM_TOKEN = 'leaked-npm-token';
+      process.env.NODE_AUTH_TOKEN = 'leaked-node-auth-token';
+
+      try {
+        const sanitized = depup.buildSanitizedInstallEnvironment();
+
+        expect(sanitized.NPM_TOKEN).toBeUndefined();
+        expect(sanitized.NODE_AUTH_TOKEN).toBeUndefined();
+        // Unrelated env vars must survive so npm can still resolve its PATH.
+        expect(sanitized.PATH).toBe(originalPath);
+      } finally {
+        if (originalNpmToken === undefined) {
+          delete process.env.NPM_TOKEN;
+        } else {
+          process.env.NPM_TOKEN = originalNpmToken;
+        }
+        if (originalNodeAuthToken === undefined) {
+          delete process.env.NODE_AUTH_TOKEN;
+        } else {
+          process.env.NODE_AUTH_TOKEN = originalNodeAuthToken;
+        }
+      }
+    });
+
+    it('does not mutate the parent process environment', () => {
+      const originalNpmToken = process.env.NPM_TOKEN;
+      process.env.NPM_TOKEN = 'stays-in-parent-env';
+
+      try {
+        depup.buildSanitizedInstallEnvironment();
+
+        expect(process.env.NPM_TOKEN).toBe('stays-in-parent-env');
+      } finally {
+        if (originalNpmToken === undefined) {
+          delete process.env.NPM_TOKEN;
+        } else {
+          process.env.NPM_TOKEN = originalNpmToken;
+        }
+      }
+    });
+  });
+
+  describe('installBuildDeps', () => {
+    it('builds the install subprocess env via the token-scrubbing helper', () => {
+      // execFileSync uses a named import bound at module load, so it cannot be
+      // patched from here. Instead, spy on the shared helper (proving the
+      // build-deps path routes through the same sanitization the helper tests
+      // verify strips both tokens) and point the install at a nonexistent cwd
+      // so execFileSync throws synchronously -- installBuildDeps swallows it.
+      const originalNpmToken = process.env.NPM_TOKEN;
+      const originalNodeAuthToken = process.env.NODE_AUTH_TOKEN;
+      process.env.NPM_TOKEN = 'leaked-npm-token';
+      process.env.NODE_AUTH_TOKEN = 'leaked-node-auth-token';
+
+      const environmentSpy = jest.spyOn(
+        depup,
+        'buildSanitizedInstallEnvironment',
+      );
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        depup.installBuildDeps('/nonexistent/path/xyz123', false);
+
+        expect(environmentSpy).toHaveBeenCalledTimes(1);
+        const builtEnvironment = environmentSpy.mock.results[0].value;
+        expect(builtEnvironment.NPM_TOKEN).toBeUndefined();
+        expect(builtEnvironment.NODE_AUTH_TOKEN).toBeUndefined();
+      } finally {
+        environmentSpy.mockRestore();
+        warnSpy.mockRestore();
+        if (originalNpmToken === undefined) {
+          delete process.env.NPM_TOKEN;
+        } else {
+          process.env.NPM_TOKEN = originalNpmToken;
+        }
+        if (originalNodeAuthToken === undefined) {
+          delete process.env.NODE_AUTH_TOKEN;
+        } else {
+          process.env.NODE_AUTH_TOKEN = originalNodeAuthToken;
+        }
+      }
+    });
+  });
+
   describe('isDepupPrereleaseVersion', () => {
     it('detects depup prerelease IDs', () => {
       expect(depup.isDepupPrereleaseVersion(['depup', 0])).toBe(true);

--- a/scripts/__tests__/unit.test.js
+++ b/scripts/__tests__/unit.test.js
@@ -262,6 +262,89 @@ describe('depUp class', () => {
     });
   });
 
+  // Regression coverage for the install-script token-exfiltration fix:
+  // untrusted packages (and their transitive deps) must never run
+  // lifecycle scripts while NPM_TOKEN/NODE_AUTH_TOKEN are reachable.
+  describe('getProductionInstallMethods', () => {
+    it('includes --ignore-scripts on every install variant', () => {
+      const methods = depup.getProductionInstallMethods();
+
+      expect(methods.length).toBeGreaterThan(0);
+      for (const [command, commandArguments] of methods) {
+        expect(command).toBe('npm');
+        expect(commandArguments).toContain('--ignore-scripts');
+      }
+    });
+  });
+
+  describe('getTestInstallMethods', () => {
+    it('includes --ignore-scripts on every install variant', () => {
+      const methods = depup.getTestInstallMethods();
+
+      expect(methods.length).toBeGreaterThan(0);
+      for (const [command, commandArguments] of methods) {
+        expect(command).toBe('npm');
+        expect(commandArguments).toContain('--ignore-scripts');
+      }
+    });
+  });
+
+  describe('tryInstallMethods', () => {
+    it('scrubs NPM_TOKEN and NODE_AUTH_TOKEN from the install subprocess environment', () => {
+      const originalNpmToken = process.env.NPM_TOKEN;
+      const originalNodeAuthToken = process.env.NODE_AUTH_TOKEN;
+      process.env.NPM_TOKEN = 'leaked-npm-token';
+      process.env.NODE_AUTH_TOKEN = 'leaked-node-auth-token';
+
+      try {
+        // This subprocess exits non-zero if either token is visible, so a
+        // `true` result proves the tokens were scrubbed before spawning.
+        const methods = [
+          [
+            'node',
+            [
+              '-e',
+              'if (process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN) { process.exit(1); }',
+            ],
+          ],
+        ];
+
+        expect(
+          depup.tryInstallMethods(methods, process.cwd(), false, 20_000),
+        ).toBe(true);
+      } finally {
+        if (originalNpmToken === undefined) {
+          delete process.env.NPM_TOKEN;
+        } else {
+          process.env.NPM_TOKEN = originalNpmToken;
+        }
+        if (originalNodeAuthToken === undefined) {
+          delete process.env.NODE_AUTH_TOKEN;
+        } else {
+          process.env.NODE_AUTH_TOKEN = originalNodeAuthToken;
+        }
+      }
+    });
+
+    it('does not mutate the parent process environment', () => {
+      const originalNpmToken = process.env.NPM_TOKEN;
+      process.env.NPM_TOKEN = 'stays-in-parent-env';
+
+      try {
+        const methods = [['node', ['-e', 'process.exit(0)']]];
+        depup.tryInstallMethods(methods, process.cwd(), false, 20_000);
+
+        expect(process.env.NPM_TOKEN).toBe('stays-in-parent-env');
+      } finally {
+        if (originalNpmToken === undefined) {
+          delete process.env.NPM_TOKEN;
+        } else {
+          process.env.NPM_TOKEN = originalNpmToken;
+        }
+      }
+    });
+  });
+
   describe('isDepupPrereleaseVersion', () => {
     it('detects depup prerelease IDs', () => {
       expect(depup.isDepupPrereleaseVersion(['depup', 0])).toBe(true);
@@ -812,6 +895,23 @@ describe('readmeGenerator class', () => {
       const result = await generator.loadJsonSafe('/nonexistent.json', 'test');
 
       expect(result).toStrictEqual({});
+    });
+  });
+
+  // Regression coverage: process.argv[2] flows into a filesystem path with
+  // no traversal guard of its own -- defense-in-depth in case a caller
+  // ever passes an unsanitized package name.
+  describe('generateReadme path traversal guard', () => {
+    it('rejects a package name that escapes the packages root', async () => {
+      await expect(
+        generator.generateReadme('../../etc/passwd'),
+      ).rejects.toThrow('Path traversal');
+    });
+
+    it('rejects a deeply nested traversal attempt', async () => {
+      await expect(
+        generator.generateReadme('../../../../etc/shadow'),
+      ).rejects.toThrow('Path traversal');
     });
   });
 });

--- a/scripts/compatibility-test.mjs
+++ b/scripts/compatibility-test.mjs
@@ -301,8 +301,10 @@ class CompatibilityTester {
 
   async testInstallation(packagePath, results) {
     try {
-      // Test npm install
-      execFileSync('npm', ['install', '--dry-run'], {
+      // Test npm install (--dry-run never executes lifecycle scripts, but
+      // --ignore-scripts is added as defense-in-depth against untrusted
+      // package code regardless of how this method is invoked)
+      execFileSync('npm', ['install', '--dry-run', '--ignore-scripts'], {
         cwd: packagePath,
         stdio: 'pipe',
         timeout: 60_000,

--- a/scripts/depup.mjs
+++ b/scripts/depup.mjs
@@ -12,6 +12,9 @@ import semver from 'semver';
 import { isNonSemverSpecifier, toScopedName } from './utilities.mjs';
 
 const PACKAGE_JSON = 'package.json';
+// Untrusted packages (and their transitive deps) must never run lifecycle
+// scripts, so every install variant below is required to pass this flag.
+const IGNORE_SCRIPTS = '--ignore-scripts';
 
 class DepUp {
   async main() {
@@ -729,14 +732,8 @@ class DepUp {
       installSpinner.stop();
     }
 
-    const installMethods = [
-      ['npm', ['install', '--omit=dev']],
-      ['npm', ['install', '--omit=dev', '--legacy-peer-deps']],
-      ['npm', ['install', '--omit=dev', '--force', '--ignore-scripts']],
-    ];
-
     const success = this.tryInstallMethods(
-      installMethods,
+      this.getProductionInstallMethods(),
       packageDirectory,
       debug,
       timeout,
@@ -756,11 +753,27 @@ class DepUp {
     }
   }
 
+  // Every variant below MUST include --ignore-scripts: these installs run
+  // against untrusted third-party packages while NPM_TOKEN is present in
+  // the environment, so lifecycle scripts must never execute here.
+  getProductionInstallMethods() {
+    return [
+      ['npm', ['install', '--omit=dev', IGNORE_SCRIPTS]],
+      ['npm', ['install', '--omit=dev', '--legacy-peer-deps', IGNORE_SCRIPTS]],
+      ['npm', ['install', '--omit=dev', '--force', IGNORE_SCRIPTS]],
+    ];
+  }
+
   tryInstallMethods(methods, directory, debug, timeout) {
+    const sanitizedEnvironment = { ...process.env };
+    delete sanitizedEnvironment.NODE_AUTH_TOKEN;
+    delete sanitizedEnvironment.NPM_TOKEN;
+
     for (const [command, commandArguments] of methods) {
       try {
         execFileSync(command, commandArguments, {
           cwd: directory,
+          env: sanitizedEnvironment,
           stdio: debug ? 'inherit' : 'pipe',
           timeout: Math.min(timeout / 4, 60_000),
         });
@@ -831,14 +844,8 @@ try {
       testInstallSpinner.stop();
     }
 
-    const testInstallMethods = [
-      ['npm', ['install']],
-      ['npm', ['install', '--legacy-peer-deps']],
-      ['npm', ['install', '--force', '--ignore-scripts']],
-    ];
-
     const success = this.tryInstallMethods(
-      testInstallMethods,
+      this.getTestInstallMethods(),
       testDirectory,
       debug,
       timeout,
@@ -856,6 +863,17 @@ try {
         );
       }
     }
+  }
+
+  // Every variant below MUST include --ignore-scripts: these installs run
+  // against untrusted third-party packages while NPM_TOKEN is present in
+  // the environment, so lifecycle scripts must never execute here.
+  getTestInstallMethods() {
+    return [
+      ['npm', ['install', IGNORE_SCRIPTS]],
+      ['npm', ['install', '--legacy-peer-deps', IGNORE_SCRIPTS]],
+      ['npm', ['install', '--force', IGNORE_SCRIPTS]],
+    ];
   }
 
   async executeImportTest(testDirectory, debug, timeout) {
@@ -941,7 +959,7 @@ try {
       console.log('Installing devDependencies for build tools...');
     }
     try {
-      execFileSync('npm', ['install', '--ignore-scripts'], {
+      execFileSync('npm', ['install', IGNORE_SCRIPTS], {
         cwd: packageDirectory,
         stdio: debug ? 'inherit' : 'pipe',
         timeout: 60_000,

--- a/scripts/depup.mjs
+++ b/scripts/depup.mjs
@@ -764,10 +764,18 @@ class DepUp {
     ];
   }
 
-  tryInstallMethods(methods, directory, debug, timeout) {
+  // Clone of process.env with the publish tokens stripped, so install
+  // subprocesses running untrusted package code can never read them.
+  // Returns a fresh object -- never mutates the real process.env.
+  buildSanitizedInstallEnvironment() {
     const sanitizedEnvironment = { ...process.env };
     delete sanitizedEnvironment.NODE_AUTH_TOKEN;
     delete sanitizedEnvironment.NPM_TOKEN;
+    return sanitizedEnvironment;
+  }
+
+  tryInstallMethods(methods, directory, debug, timeout) {
+    const sanitizedEnvironment = this.buildSanitizedInstallEnvironment();
 
     for (const [command, commandArguments] of methods) {
       try {
@@ -961,6 +969,7 @@ try {
     try {
       execFileSync('npm', ['install', IGNORE_SCRIPTS], {
         cwd: packageDirectory,
+        env: this.buildSanitizedInstallEnvironment(),
         stdio: debug ? 'inherit' : 'pipe',
         timeout: 60_000,
       });

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -72,7 +72,14 @@ This package inherits the license from [{{originalPackage}}](https://www.npmjs.c
   }
 
   async generateReadme(packageName) {
-    const packageDirectory = path.join(process.cwd(), 'packages', packageName);
+    const packagesRoot = path.resolve(process.cwd(), 'packages');
+    const packageDirectory = path.join(packagesRoot, packageName);
+    if (!packageDirectory.startsWith(packagesRoot + path.sep)) {
+      throw new Error(
+        `Path traversal detected in package name: ${packageName}`,
+      );
+    }
+
     const integrityFile = path.join(packageDirectory, 'integrity.json');
 
     const integrityData = await this.loadJsonSafe(


### PR DESCRIPTION
## Summary

Security-audit follow-through for depup. There was no outstanding security-scan report to triage (the secure-processing workflow is manual-dispatch only, last ran ~4 months ago, and its reports expire after 7 days), so depup's live security surface was audited directly. That audit surfaced one **confirmed critical** vulnerability, which this PR fixes, plus a low-severity hardening item.

## Critical fix: npm publish-token exfiltration via untrusted install scripts

**The vulnerability (verified against the actual files, all three links confirmed):**

- The package-request issue template auto-applies the `package-request` label, and the processing workflow triggers on that label — so **any member of the public** can trigger the immediate publish pipeline with an arbitrary npm package, no collaborator access required.
- That workflow runs the core processor directly with `--test --publish` and the npm publish token (`NPM_TOKEN` / `NODE_AUTH_TOKEN`) in the step environment — it does **not** route through the hardened container sandbox (the sandbox that forces scripts off is only wired to the manual/allowlisted `depup-secure` workflow).
- The core install routine tried script-executing `npm install` variants **before** the `--ignore-scripts` fallback, and passed no scrubbed environment to the subprocess.

**Impact:** an attacker publishes an npm package they control whose transitive dependency has a lifecycle script, opens a depup package-request issue naming it, and depup installs it with lifecycle scripts enabled and the publish token in the environment. The script reads the token → compromise of all 1000+ published `@depup/*` packages. Publicly triggerable, unauthenticated. Also reachable via the 8-hourly cron (which processes 1000+ packages, any of which could gain a compromised transitive dep at any time).

**The fix (at the core-script boundary, so it closes all three entry points — public issues, cron, and manual dispatch — at once):**

- Every production and test install variant now passes `--ignore-scripts` unconditionally (extracted into `getProductionInstallMethods()` / `getTestInstallMethods()` so the property is directly unit-testable). Lifecycle scripts of untrusted packages and their transitive deps never execute.
- Defense-in-depth: the install subprocess now runs with a sanitized environment — a clone of `process.env` with `NPM_TOKEN` and `NODE_AUTH_TOKEN` removed (the real `process.env` is never mutated) — so the publish token is unreadable by any install-time code even if a script ever slipped through.
- `compatibility-test.mjs`'s `npm install --dry-run` probe also gets `--ignore-scripts` (defense-in-depth; `--dry-run` already skips scripts and that call site has no token in env).

## Low-severity hardening (included)

- `generate-readme.mjs` now has its own path-traversal guard (resolve packages root, reject any candidate that escapes it), mirroring the existing guard in the core validator. Callers already sanitized, so this is defense-in-depth / consistency.

## Triaged, not changed (with justification)

- **Container base image is a floating tag, not a digest** — low priority. The base is already pinned to a fixed major (`node:24-alpine`, aligned to the project's Node target in a prior commit), the image is a transient CI build artifact rebuilt every run, and it is only used by the manual/allowlisted secure workflow. Digest-pinning (with Dependabot maintaining it) is a reasonable follow-up but not urgent; left as a documented low-priority item rather than bundled into this security-critical PR.
- **depup's own dependencies** — audited clean, zero vulnerabilities at any severity. No bumps needed.
- **CI supply-chain surface** — verified clean: all GitHub Actions references are commit-SHA-pinned, user-submitted package names are sanitized before use, workflow permissions are least-scoped, no risky PR triggers, secrets are runtime-injected (not baked into images), containers run non-root.
- **Rest of the processing pipeline** — path traversal, prototype pollution, shell/command injection, `.npmrc` stripping, and symlink handling were all verified already-guarded with file-level evidence during the audit.

## Test Plan

- `npm run lint` — clean (mikey-pro strict).
- Unit suite (`scripts/__tests__/unit.test.js`) — green, including new regression tests that assert: every production and test install command includes `--ignore-scripts`; `tryInstallMethods` scrubs both tokens from the child process (proven by a spawned probe that self-exits nonzero if it can see either token) without mutating the parent `process.env`; and `generateReadme` rejects path-traversal payloads.
- CI (this PR) provides the authoritative lint + unit + integration run.
