### PR TITLE
perf(ci): relax discover cadence from daily to weekly (cut ~1,850 Actions min/mo)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,8 +2,11 @@ name: "Automated Discovery & Sync"
 
 on:
   schedule:
-    - cron: "0 8,16 * * *"  # sync + heal only (skip discover)
-    - cron: "0 0 * * *"     # full pipeline: discover + sync + heal (daily, midnight UTC)
+    - cron: "0 8,16 * * *"  # sync + heal only (skip discover), every day
+    - cron: "0 0 * * 1-6"   # sync + heal only (skip discover), midnight UTC Mon-Sat
+    - cron: "0 0 * * 0"     # full pipeline: discover + sync + heal, midnight UTC Sunday only
+                             # (discover is weekly -- new-package onboarding lags by up to
+                             # a week; the existing catalog keeps syncing deps every 8h)
   workflow_dispatch:
     inputs:
       discover_only:
@@ -30,7 +33,7 @@ jobs:
     name: Discover (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: ${{ !inputs.sync_only && (github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * *') }}
+    if: ${{ !inputs.sync_only && (github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * 0') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
Cuts GitHub Actions minute burn by relaxing the **discover** job from daily to **weekly**, with **zero** impact on the existing catalog's dep-sync freshness.

- `cron.yml` schedule split into three entries:
  - `0 8,16 * * *` — sync + heal, every day (unchanged)
  - `0 0 * * 1-6` — sync + heal at midnight Mon–Sat (discover skipped)
  - `0 0 * * 0` — full pipeline (discover + sync + heal) at midnight Sunday only
- Discover job's schedule gate updated `'0 0 * * *'` → `'0 0 * * 0'`.
- **Sync still fires 3×/day every day** (the "sync every 8h" processing contract is preserved). Only new-package discovery moves to weekly.

### Cost impact (from real historical per-job Actions durations)
- Discover ≈ 72 min/run. Daily (30/mo) ≈ 2,161 min/mo → weekly (~4.3/mo) ≈ 312 min/mo.
- **Savings ≈ 1,850 min/mo**, no sync-freshness tradeoff. Brings projected burn ~6,700 → ~4,850 min/mo.
- Tradeoff: new curated packages onboard up to ~7 days slower (existing catalog unaffected).

Only `.github/workflows/cron.yml` changes (9 lines). The existing `npm whoami` fail-fast guard is kept.

## Test Plan
- `actionlint` clean (only pre-existing SC2086 info warnings, identical on main).
- YAML parses; schedule entries verified as `['0 8,16 * * *', '0 0 * * 1-6', '0 0 * * 0']`.
- Real Actions run on this branch (`workflow_dispatch`, run 29684975925) launched the full job graph and aborted at the credential guard as designed — proves the branch YAML is valid and job wiring is intact.
- Schedule-gate mechanism is identical to main's already-live behavior (midnight attempts discover, 08/16 skips it).

## Follow-ups (NOT blocking this PR — merge this on its own)
1. **Deeper sync-partition cut (recommended: skip).** A rotating/incremental sync could save ~1,700 more min/mo on paper, but the real driver of sync cost (install+test+publish of packages that actually need updates) is not reduced by rotation — only the cheap registry-check phase is — and it adds a per-package freshness delay (8h → ~24h). Low, murky value; left as a costed option, not implemented here.
2. **`NPM_TOKEN` refresh (operational, higher priority than this PR).** The token expired ~2026-06-16; every scheduled run since fails fast at the guard, so depup has published/synced nothing for ~33 days. Rotate the npm automation token and update the repo secret to bring the factory back online — that also enables the first real green run (and the first live weekly-discover Sunday run) to confirm these savings.