### PR TITLE
fix(ci): fail-fast on dead NPM_TOKEN in bump.yml (mirror cron preflight)

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -41,6 +41,15 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify npm auth (fail fast on dead NPM_TOKEN)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if ! npm whoami; then
+            echo "::error::NPM_TOKEN is invalid or expired (npm whoami failed). Rotate the npm automation token at npmjs.com and update the NPM_TOKEN repo secret. Aborting early to avoid wasting CI minutes."
+            exit 1
+          fi
+
       - name: Install Dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Adds the `npm whoami` fail-fast preflight to `bump.yml` ("Sync All Packages"), mirroring the already-merged cron.yml guard (PR #1276). This is the one remaining Actions-minute optimization worth shipping after profiling depup's real usage.

## Why (profiling result)

Pulled real GitHub Actions timing for the last 30 days:

| Workflow | Runs/mo | Avg/run | Min/mo | State |
|---|---|---|---|---|
| **bump.yml** | ~8 | **~27 min** | **~216** | FAILING (no preflight) |
| cron.yml | 90 | ~81 s | ~121 | fail-fast (preflight present) |
| test.yml | 50 | ~45 s | ~37 | ok |
| others | ~38 | varies | ~40 | ok |

- **`bump.yml` is the largest minute consumer** and it lacks the auth preflight cron.yml already has. Every push-triggered run grinds ~27 min (one hit the 30-min ceiling) before failing at the publish step on a dead/expired `NPM_TOKEN`.
- cron.yml already aborts these in ~81 s thanks to PR #1276 — this PR extends the same proven pattern to bump.yml.

## Change

One step inserted between "Setup Node.js" and "Install Dependencies" — byte-identical to the merged cron preflight. Aborts in seconds with an actionable error when `npm whoami` returns 401, instead of burning ~27 min to fail at publish.

## Context: this does NOT make the pipeline green

The root cause of the failures is that the **`NPM_TOKEN` secret is expired/revoked on npm's side** (unchanged since 2026-01-13; failing every run since ~2026-06-16). That requires minting a fresh npm automation token at npmjs.com (login + 2FA) and updating the `NPM_TOKEN` repo secret — out of CI scope. This PR only stops bump.yml from wasting minutes while the token is dead (and on any future token expiry). Note: depup is a **public** repo, so these minutes are within the free tier ($0) — this is waste-reduction/hardening, not a cost fix.

## Deferred low-risk levers (validated, not included here to keep this focused)

- **`filter: blob:none`** on cron.yml checkouts — skips ~288 MB of historical package blobs per checkout, keeps full history for the rebase loop (cross-checked SAFE). ~7 full-history clones/run today.
- **Shard-filter-before-read in `cron-sync.mjs`** (`getExistingPackages`) — currently every shard reads+parses all ~2,232 `integrity.json` files then filters; sharding before the read cuts each shard's Phase-1 I/O ~3x.
- **Target-tarball cache gap** — `setup-node`'s npm cache is keyed on the lockfile hash, so its save step is skipped on hits and pacote-downloaded target tarballs never persist across runs. A separate date-keyed `actions/cache` on `~/.npm/_cacache` would let them accumulate.

## Test plan

- YAML validated (`yaml.safe_load`) + actionlint clean.
- Change is a verbatim copy of the merged, in-production cron.yml preflight step.
- Cannot produce live before/after minutes: the pipeline fails fast (81 s) while the token is dead, so a healthy-run measurement requires the token to be rotated first. Projected impact: bump.yml failing runs ~27 min -> ~1 min while token is dead.