### PR TITLE
ci: build both container images so Dockerfile.security stops rotting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,79 @@
+name: Docker Build Verification
+
+# Build-only verification for BOTH container images.
+#
+# This is the ONLY CI job that exercises Dockerfile.security. It is otherwise
+# referenced solely by docker-compose.yml (which no workflow runs), so it rots
+# silently -- it has previously accumulated latent build bugs (a non-existent
+# npm package and a missing chown that broke `npm ci` as the non-root user),
+# caught only by a manual local build.
+#
+# No image is run, pushed, or published here. The build fully executes every
+# RUN layer, which is exactly what catches Dockerfile build regressions, with
+# zero external side effects -- unlike depup-secure.yml, which is
+# dispatch-only and publishes to npm + pushes to main and therefore must never
+# be triggered merely to prove a container builds.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile.security'
+      - 'docker-compose.yml'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docker-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile.security'
+      - 'docker-compose.yml'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docker-build.yml'
+  workflow_dispatch:
+
+# Build-only: no registry push, no repo write. Read is all that is needed.
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }} image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: sandbox
+            file: ./Dockerfile
+            tag: depup-security-sandbox:ci
+          - image: scanner
+            file: ./Dockerfile.security
+            tag: depup-security-scanner:ci
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build ${{ matrix.image }} image (build-only, no push, no run)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          tags: ${{ matrix.tag }}
+          push: false
+          load: false


### PR DESCRIPTION
## Summary

`Dockerfile.security` (the security-scanner image) is built by **nothing** in CI. It is referenced only by `docker-compose.yml`, and no workflow runs `docker compose`, so it rots silently -- it has previously accumulated latent build bugs (a non-existent npm package `@snyk/cli`, and a missing `chown /app` that broke `npm ci` as the non-root user), caught only by a manual local build.

The only `docker build` anywhere in CI is `depup-secure.yml`'s `container-build` job, which correctly builds `./Dockerfile` (the processing sandbox). Nothing exercises `Dockerfile.security`.

This adds a **build-only** verification workflow that builds **both** images with no run, push, or publish. It fully executes every RUN layer -- exactly what catches Dockerfile build regressions -- with zero external side effects.

Deliberately does **not** touch `depup-secure.yml`: that workflow is `workflow_dispatch`-only and **publishes to npm + pushes to `main`**, so it must never be triggered merely to prove a container builds.

## Design
- Native GitHub Actions (no offload).
- Matrix over both Dockerfiles: `sandbox` (`./Dockerfile`) and `scanner` (`./Dockerfile.security`).
- `push: false`, `load: false` -- build-only.
- `permissions: contents: read` only.
- Pinned action SHAs matching repo convention.
- Paths-filtered to `Dockerfile`, `Dockerfile.security`, `docker-compose.yml`, `scripts/**`, package manifests, and the workflow itself. `workflow_dispatch` enabled for safe on-demand verification.

## Test plan
- `actionlint` on the workflow: PASS.
- Local build of **both** images from the worktree (the exact CI gate): both SUCCESS.
- This PR's own CI run builds both images clean-slate on a GitHub runner -- see checks.