### PR TITLE
chore: pin Docker base images to digest hashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DepUp Security Sandbox - Isolated Package Processing Environment
-FROM node:24-alpine
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # Install security tools and dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.security
+++ b/Dockerfile.security
@@ -1,5 +1,5 @@
 # DepUp Security Scanner - Pre-publication Security Validation
-FROM node:24-alpine
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # Install security scanning tools
 RUN apk add --no-cache \


### PR DESCRIPTION
## Summary
Pin `node:24-alpine` to its immutable digest hash in both `Dockerfile` and `Dockerfile.security`. This prevents repo tag mutations (docker push/rebuild with the same tag name but different content).

**Images updated:**
- Both container images: `node:24-alpine@sha256:a0b9bf...` (currently pinned to July 2026 build)

## Test plan
- `docker-build.yml` CI: build both Dockerfiles, verify no regressions
- Local build test: both Dockerfiles build successfully with pinned digest