### PR TITLE
chore(ci): add Dependabot docker ecosystem to auto-bump base-image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,17 @@ updates:
       npm:
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    ignore:
+      # clamav/clamav has no arm64 manifest and its docker-compose.yml pin is
+      # a deliberately deferred separate decision -- never auto-bump it here.
+      - dependency-name: "clamav/clamav"


### PR DESCRIPTION
## Summary

- The `docker-version-monitor` alert flagging "2 Docker image updates available" is **already resolved on `main`**: both `Dockerfile` and `Dockerfile.security` are pinned to the current `node:24-alpine@sha256:a0b9bf06...` digest (verified against the live Docker Hub registry API and `docker buildx imagetools` -- zero drift). The "2" in the alert was a stale pre-merge snapshot from when both Dockerfiles were still on `node:20-alpine`, before #1275 (20->24) and #1285 (digest pin) merged.
- This PR is the **durable fix** so this doesn't turn into a recurring manual fire-drill: it adds a third `package-ecosystem: "docker"` entry to `.github/dependabot.yml`, matching the existing `github-actions`/`npm` entries' style (weekly schedule, `chore` commit prefix, single `groups` block).
- A single `directory: "/"` entry is sufficient to cover **both** root Dockerfiles. Verified directly against the current `dependabot-core` source (`docker/lib/dependabot/docker/file_fetcher.rb`): the file-detection regex is `/dockerfile|containerfile/i`, a case-insensitive substring match against every file in the configured directory -- not an exact-name match. So `Dockerfile` and `Dockerfile.security` are both picked up automatically. (Confirmed this in a maintainer comment on [dependabot/dependabot-core#4449](https://github.com/dependabot/dependabot-core/issues/4449) too.) `docker-compose.yml` in the same directory is also covered by Dependabot's shared YAML-file detection.
- `clamav/clamav` is explicitly excluded via `ignore:` inside the new docker entry -- it has no arm64 manifest and its `docker-compose.yml` pin is a deliberately deferred, separate decision. Dependabot should never try to auto-bump it.

## Test plan

- [x] `git diff` against `origin/main` touches only `.github/dependabot.yml` (14 lines added, nothing else).
- [x] YAML validated: `python3 -c "import yaml,sys; print(yaml.safe_load(open('.github/dependabot.yml')))"` parses cleanly with the new `docker` entry present (`ignore: [{'dependency-name': 'clamav/clamav'}]`).
- [x] Confirmed against current `dependabot-core` source that a single `directory: "/"` entry detects both `Dockerfile` and `Dockerfile.security` (case-insensitive substring match on filename, not exact match) -- no need for the `directories` (plural) form or a second entry.
- Not run (out of scope / would trigger publish side effects): `depup-secure.yml` or any workflow dispatch. This PR only touches Dependabot config, not the Docker build itself.