### PR TITLE
chore(ci): pin Dependabot to Node 24 LTS for base images (decline node 26 Current)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,10 @@ updates:
       # clamav/clamav has no arm64 manifest and its docker-compose.yml pin is
       # a deliberately deferred separate decision -- never auto-bump it here.
       - dependency-name: "clamav/clamav"
+      # Node 24 is depup's standard runtime (Active LTS "Krypton", EOL 2028-04-30).
+      # Node 26 stays "Current" until it enters Active LTS on 2026-10-28 -- do not
+      # auto-jump the base image off the LTS line onto a pre-LTS major. Digest,
+      # patch, and minor refreshes of node:24-alpine still flow through normally.
+      # Remove this rule once Node 26 reaches Active LTS to move to the next LTS.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Resolves the recurring `docker-version-monitor` "Docker image update available" alert **correctly**, without moving off the LTS line.

**Reconciled state (the alert's premise was stale):**
- Both `Dockerfile` and `Dockerfile.security` on `main` are **already** pinned to the current latest `node:24-alpine` digest (`sha256:a0b9bf06...`, node 24.18.0) — confirmed against Docker Hub, nothing to bump on the 24 line.
- The only available "update" is Dependabot **#1287** bumping `node:24-alpine -> 26-alpine`. Node 26 is **"Current," not Active LTS until 2026-10-28** (~100 days out). Node 24 is **Active LTS "Krypton," EOL 2028-04-30**.
- depup's documented standard is **Node.js 24 LTS**, and the base images were *just* deliberately moved to 24 (PRs #1275/#1276/#1285). Jumping to 26 now would invert that decision.

**This change:** adds a Dependabot ignore rule for node **semver-major** bumps, so the base image stays on the 24 LTS major. Digest/patch/minor refreshes of `node:24-alpine` still flow (image stays patched). Remove the rule once Node 26 reaches Active LTS.

## Test Plan
- Config-only change to `.github/dependabot.yml` — does not touch Docker/scripts/manifest paths, so `docker-build.yml` does not (and need not) run on it.
- Current `node:24-alpine` images verified green **today** via a fresh `docker-build.yml` `workflow_dispatch` on main (run 29739463144): **Build sandbox image = success, Build scanner image = success**.

## Follow-ups (recommend, not done here)
- **Close #1287** (node 24 -> 26, off-LTS) — superseded by this pin.
- **Close #1278** (20 -> 24, stale) — main is already on 24.
- **#1288** (buildx action 4.1.0 -> 4.2.0, SHA-pinned) is a safe in-convention patch — OK to merge.
